### PR TITLE
Stratified Type Inference

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,2 @@
+- Coercion insertion (stratified inference)
+- Invariants (already done for coercion inference)

--- a/src/constraints/constraint/constraint.ml
+++ b/src/constraints/constraint/constraint.ml
@@ -110,17 +110,13 @@ module Make (Algebra : Algebra) = struct
   and 'a term_let_rec_binding = term_binding * 'a bound
 
   module Rigid = struct
-    type t =
-      | True
-      | Conj of t list
-      | Eq of Type.t * Type.t
-    [@@deriving sexp_of]
+    type t = (Type.t * Type.t) list [@@deriving sexp_of]
 
-    let true_ = True
-    let conj t1 t2 = Conj [ t1; t2 ]
+    let is_empty t = List.is_empty t
 
-    let of_equations equations =
-      Conj (List.map equations ~f:(fun (t1, t2) -> Eq (t1, t2)))
+    let true_ = []
+    let and_ t1 t2 = t1 @ t2
+    let of_equations equations = equations
   end
 
   (* ['a t] is a constraint with value type ['a]. *)

--- a/src/constraints/constraint/constraint.mli
+++ b/src/constraints/constraint/constraint.mli
@@ -113,16 +113,17 @@ module Make (Algebra : Algebra) : sig
 
        A rigid constraint R is defined by:
          R ::= true | R && R | t = t
+
+       Due to the simplicitly of this structure, we optimize it to a list
+       of equality constraints.
     *)
 
-    type t =
-      | True
-      | Conj of t list
-      | Eq of Type.t * Type.t
-    [@@deriving sexp_of]
+    type t = (Type.t * Type.t) list [@@deriving sexp_of]
+
+    val is_empty : t -> bool
 
     val true_ : t
-    val conj : t -> t -> t
+    val and_ : t -> t -> t
     val of_equations : (Type.t * Type.t) list -> t
   end
 

--- a/src/constraints/constraint/constraint.mli
+++ b/src/constraints/constraint/constraint.mli
@@ -115,7 +115,7 @@ module Make (Algebra : Algebra) : sig
          R ::= true | R && R | t = t
     *)
 
-    type t = 
+    type t =
       | True
       | Conj of t list
       | Eq of Type.t * Type.t
@@ -123,7 +123,6 @@ module Make (Algebra : Algebra) : sig
 
     val true_ : t
     val conj : t -> t -> t
-
     val of_equations : (Type.t * Type.t) list -> t
   end
 
@@ -154,7 +153,7 @@ module Make (Algebra : Algebra) : sig
       (** [match C with (... | (x₁ : ɑ₁ ... xₙ : ɑₙ) -> Cᵢ | ...)]. *)
     | Decode : variable -> Types.Type.t t 
       (** [decode ɑ] *)
-    | Implication : Rigid.t * 'a t -> 'a t
+    | Implication : Rigid.t * 'a t -> 'a t 
       (** [R => C] *)
     | Eq_modulo : variable * variable -> unit t
       (** [t1 =% t2] (used to determine equality based on implication) *)
@@ -172,9 +171,15 @@ module Make (Algebra : Algebra) : sig
         }
 
   and 'a let_rec_binding =
-    | Let_rec_binding of
+    | Let_rec_mono_binding of
         { rigid_vars : variable list
         ; flexible_vars : Shallow_type.binding list
+        ; binding : binding
+        ; in_ : 'a t
+        }
+    | Let_rec_poly_binding of
+        { rigid_vars : variable list
+        ; annotation_bindings : Shallow_type.binding list
         ; binding : binding
         ; in_ : 'a t
         }
@@ -254,9 +259,13 @@ module Make (Algebra : Algebra) : sig
     -> binding
     -> 'a let_rec_binding
 
-  val (#=>) : Rigid.t -> 'a t -> 'a t
+  val ( #~> )
+    :  variable list * Shallow_type.binding list * 'a t
+    -> binding
+    -> 'a let_rec_binding
 
-  val (=%) : variable -> variable -> unit t
+  val ( #=> ) : Rigid.t -> 'a t -> 'a t
+  val ( =% ) : variable -> variable -> unit t
 
   (** [let_ ~bindings ~in_] binds the let bindings [bindings] in the constraint [in_]. *)
   val let_

--- a/src/constraints/constraints.ml
+++ b/src/constraints/constraints.ml
@@ -18,14 +18,12 @@ module Make (Algebra : Algebra) = struct
   include Private.Constraint.Make (Algebra)
 
   module Rigid = struct
-    let rec to_constraint t =
-      match t with
-      | Rigid.True -> True
-      | Rigid.Conj ts -> List.map ~f:to_constraint ts |> all_unit
-      | Rigid.Eq (t1, t2) ->
+    let to_constraint t =
+      List.map t ~f:(fun (t1, t2) ->
         let bindings1, t1 = Shallow_type.of_type t1 in
         let bindings2, t2 = Shallow_type.of_type t2 in
-        exists (bindings1 @ bindings2) (t1 =~ t2)
+        exists (bindings1 @ bindings2) (t1 =~ t2))
+      |> all_unit
 
 
     include Rigid

--- a/src/constraints/constraints.mli
+++ b/src/constraints/constraints.mli
@@ -216,6 +216,22 @@ module Make (Algebra : Algebra) : sig
     :  bindings:'a let_rec_binding list
     -> in_:'b t
     -> ('a term_let_rec_binding list * 'b) t
+
+  module Rigid : sig
+    type 'a constraint_ := 'a t
+
+    type t [@@deriving sexp_of]
+    
+    val true_ : t
+    val conj : t -> t -> t
+
+    val of_equations : (Type.t * Type.t) list -> t
+    val to_constraint : t -> unit constraint_
+  end
+
+  val ( #=> ) : Rigid.t -> 'a t -> 'a t
+
+  val ( =% ) : variable -> variable -> unit t
 end
 
 module Private : sig

--- a/src/constraints/constraints.mli
+++ b/src/constraints/constraints.mli
@@ -225,8 +225,10 @@ module Make (Algebra : Algebra) : sig
     type 'a constraint_ := 'a t
     type t [@@deriving sexp_of]
 
+    val is_empty : t -> bool
+
     val true_ : t
-    val conj : t -> t -> t
+    val and_ : t -> t -> t
     val of_equations : (Type.t * Type.t) list -> t
     val to_constraint : t -> unit constraint_
   end

--- a/src/constraints/constraints.mli
+++ b/src/constraints/constraints.mli
@@ -28,7 +28,6 @@ module Make (Algebra : Algebra) : sig
   (** [variable] is the for the constraint variables *)
   type variable = private int
 
-
   (** A constraint of type ['a Constraint.t] represents a constraint of
     type ['a]. 
     
@@ -204,6 +203,11 @@ module Make (Algebra : Algebra) : sig
     -> binding
     -> 'a let_rec_binding
 
+  val ( #~> )
+    :  variable list * Shallow_type.binding list * 'a t
+    -> binding
+    -> 'a let_rec_binding
+
   (** [let_ ~bindings ~in_] binds the let bindings [bindings] in the constraint [in_]. *)
   val let_
     :  bindings:'a let_binding list
@@ -219,18 +223,15 @@ module Make (Algebra : Algebra) : sig
 
   module Rigid : sig
     type 'a constraint_ := 'a t
-
     type t [@@deriving sexp_of]
-    
+
     val true_ : t
     val conj : t -> t -> t
-
     val of_equations : (Type.t * Type.t) list -> t
     val to_constraint : t -> unit constraint_
   end
 
   val ( #=> ) : Rigid.t -> 'a t -> 'a t
-
   val ( =% ) : variable -> variable -> unit t
 end
 

--- a/src/constraints/solver/equations.ml
+++ b/src/constraints/solver/equations.ml
@@ -1,0 +1,142 @@
+(*****************************************************************************)
+(*                                                                           *)
+(*                                Dromedary                                  *)
+(*                                                                           *)
+(*                Alistair O'Brien, University of Cambridge                  *)
+(*                                                                           *)
+(* Copyright 2021 Alistair O'Brien.                                          *)
+(*                                                                           *)
+(* All rights reserved. This file is distributed under the terms of the MIT  *)
+(* license, as described in the file LICENSE.                                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+open! Import
+include Equations_intf
+
+module Make
+    (Former : Type_former.S)
+    (Metadata : Unifier.Metadata)
+    (Unifier : Unifier.S
+                 with type 'a former := 'a Former.t
+                  and type metadata := Metadata.t) =
+struct
+  module U = Unifier
+
+  module Equation = struct
+    type t = U.Type.t * U.Type.t [@@deriving sexp_of]
+
+    let ( =%= ) t1 t2 = t1, t2
+  end
+
+  type t = Equation.t list
+
+  let empty = []
+
+
+  let pp_type_explicit type_ =
+    let rec pp_type_explicit type_ =
+      match U.Type.get_structure type_ with
+      | U.Type.Var { flexibility = _ } ->
+        Sexp.Atom (Int.to_string (U.Type.id type_))
+      | U.Type.Former former -> Former.sexp_of_t pp_type_explicit former
+    in
+    Caml.Format.printf "%s\n" (Sexp.to_string_mach (pp_type_explicit type_))
+
+
+  let pp_type type_ =
+    Caml.Format.printf
+      "id = %d"
+      (U.Type.id type_);
+    (match U.Type.get_structure type_ with
+    | Var { flexibility } ->
+      Caml.Format.printf
+        ", flexibility = %s"
+        (Sexp.to_string_hum (U.Type.sexp_of_flexibility flexibility))
+    | _ -> ());
+    Caml.Format.printf "\n";
+    pp_type_explicit type_
+
+  let pp t = 
+    if List.is_empty t then Caml.Format.printf "No equations!\n"
+    else
+    List.iter t ~f:(fun (t1, t2) ->
+      Caml.Format.printf "Equation:\n";
+      pp_type t1;
+      pp_type t2
+      )
+
+  exception Inconsistent
+
+  (* [add_equation t (t1 =. t2)] adds the solved form of the equation
+       [t1 =. t2] to the environment [t]. 
+       
+       Warning! Assumes [t1 =. t2] is not cyclic
+    *)
+  let add_equation t (type1, type2) =
+    (* Caml.Format.printf "Adding equation:\n";
+    pp_type type1;
+    pp_type type2; *)
+    (* TODO: Implement fold2_exn for Former. Removes reference side-effect. *)
+    let t = ref t in
+    let rec loop t1 t2 =
+      match U.Type.get_structure t1, U.Type.get_structure t2 with
+      | Var { flexibility = Rigid }, _ | _, Var { flexibility = Rigid } ->
+        t := (t1, t2) :: !t
+      | Former former1, Former former2 ->
+        Former.iter2_exn ~f:loop former1 former2
+      | Var { flexibility = Flexible }, _ | _, Var { flexibility = Flexible } -> 
+        raise_s [%message "Adding non-rigid equation!"]
+    in
+    (try loop type1 type2 with
+    (* If we add an equation that implies [bool = int], then the equation is
+         inconsistent *)
+    | Former.Iter2 -> raise Inconsistent);
+    !t
+
+
+  let equivalence_class t type_ =
+    List.fold_left t ~init:[ type_ ] ~f:(fun acc (type1, type2) ->
+        if U.Type.id type1 = U.Type.id type_
+        then type2 :: acc
+        else if U.Type.id type2 = U.Type.id type_
+        then type1 :: acc
+        else acc)
+
+
+  (* This is actually horrifying, but its a prototype ;) *)
+  let rec eq_modulo t type1 type2 : bool =
+    (* Caml.Format.printf "Types:\n";
+    pp_type type1;
+    pp_type type2; *)
+
+    let class1 = equivalence_class t type1
+    and class2 = equivalence_class t type2 in
+    (* Caml.Format.printf "Class1:\n";
+    List.iter class1 ~f:pp_type;
+    Caml.Format.printf "Class2:\n";
+    List.iter class2 ~f:pp_type; *)
+    (* Again, relying on exceptions for control flow. Unncessary, use fold! *)
+    let equiv t1 t2 : bool =
+      if phys_equal t1 t2
+      then true
+      else
+        let exception Not_equiv in
+        try
+          (match U.Type.get_structure t1, U.Type.get_structure t2 with
+          | Var _, Var _ -> if not (phys_equal t1 t2) then raise Not_equiv
+          | Former former1, Former former2 ->
+            Former.iter2_exn
+              ~f:(fun t1 t2 -> if not (eq_modulo t t1 t2) then raise Not_equiv)
+              former1
+              former2
+          | _, _ -> raise Not_equiv);
+          true
+        with
+        | Former.Iter2 | Not_equiv -> false
+    in
+    List.exists ~f:(List.mem ~equal:(fun t1 t2 -> U.Type.id t1 = U.Type.id t2) class1) class2
+    || List.exists
+         ~f:(fun t1 -> List.exists ~f:(fun t2 -> equiv t1 t2) class1)
+         class2
+end

--- a/src/constraints/solver/equations.mli
+++ b/src/constraints/solver/equations.mli
@@ -11,32 +11,4 @@
 (*                                                                           *)
 (*****************************************************************************)
 
-open! Import
-module Module_types = Private.Constraint.Module_types
-
-module Make (Algebra : Algebra) = struct
-  include Private.Constraint.Make (Algebra)
-
-  module Rigid = struct
-    let rec to_constraint t =
-      match t with
-      | Rigid.True -> True
-      | Rigid.Conj ts -> List.map ~f:to_constraint ts |> all_unit
-      | Rigid.Eq (t1, t2) ->
-        let bindings1, t1 = Shallow_type.of_type t1 in
-        let bindings2, t2 = Shallow_type.of_type t2 in
-        exists (bindings1 @ bindings2) (t1 =~ t2)
-
-
-    include Rigid
-  end
-
-  module Solver = Private.Solver.Make (Algebra)
-
-  let solve = Solver.solve
-end
-
-module Private = struct
-  module Constraint = Private.Constraint
-  include Private.Solver.Private
-end
+include Equations_intf.Intf (** @inline *)

--- a/src/constraints/solver/equations_intf.ml
+++ b/src/constraints/solver/equations_intf.ml
@@ -1,0 +1,77 @@
+(*****************************************************************************)
+(*                                                                           *)
+(*                                Dromedary                                  *)
+(*                                                                           *)
+(*                Alistair O'Brien, University of Cambridge                  *)
+(*                                                                           *)
+(* Copyright 2021 Alistair O'Brien.                                          *)
+(*                                                                           *)
+(* All rights reserved. This file is distributed under the terms of the MIT  *)
+(* license, as described in the file LICENSE.                                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+(* This module implements the interfaces for equations and their context. *)
+
+open! Import
+
+module type S = sig
+  (** Abstract types to be substituted by functor arguments. *)
+
+  (** The type ['a former] is the type formers (with children of type ['a]), 
+      given by the functor argument [Former]. *)
+
+  type 'a former
+
+  type metadata
+
+  module Unifier : Unifier.S with type 'a former := 'a former with type metadata := metadata
+
+  (** An equation [t : Equation.t] denotes some arbitrary equality. 
+      
+      We leave it's implementation and type abstract to provide a foundation
+      for more efficient implementations. 
+  *)
+  module Equation : sig
+    type t [@@deriving sexp_of]
+
+    (** [type1 =%= type2] returns an equation that encodes the equality 
+        between [type1] and [type2]. *)
+    val ( =%= ) : Unifier.Type.t -> Unifier.Type.t -> t
+  end
+
+  (** [t] defines an arbitrary context of equations. *)
+  type t
+
+  val pp : t -> unit
+
+  (** [empty] is the initial equational context. *)
+  val empty : t
+
+  exception Inconsistent
+
+  (** [add_equation t equation] adds the equation [equation] to [t]. 
+      [Inconsistent] is raised if we can deduce false from the context [t; equation]. 
+  *)
+  val add_equation : t -> Equation.t -> t
+
+  (** [eq_modulo t type1 type2] determines whether types [type1] and [type2] are equivalent
+      under the context [t].  
+  *)
+  val eq_modulo : t -> Unifier.Type.t -> Unifier.Type.t -> bool
+end
+
+(** The interface of {equations.ml}. *)
+
+module type Intf = sig
+  module type S = S
+
+  (** The functor [Make]. *)
+  module Make
+      (Former : Type_former.S)
+      (Metadata : Unifier.Metadata)
+      (Unifier : Unifier.S
+                   with type 'a former := 'a Former.t
+                    and type metadata := Metadata.t) :
+    S with type 'a former := 'a Former.t and type metadata := Metadata.t and module Unifier := Unifier
+end

--- a/src/constraints/solver/generalization_intf.ml
+++ b/src/constraints/solver/generalization_intf.ml
@@ -32,6 +32,9 @@ module type S = sig
   module Unifier :
     Unifier.S with type 'a former := 'a former and type metadata := Tag.t
 
+  module Equations :
+    Equations.S with type 'a former := 'a former and type metadata := Tag.t and module Unifier := Unifier
+
   (** The type [scheme] defines the abstract notion of a scheme in 
       "graphic" types.
       

--- a/src/constraints/solver/solver.ml
+++ b/src/constraints/solver/solver.ml
@@ -263,17 +263,14 @@ module Make (Algebra : Algebra) = struct
         (Type_former.map former ~f:(of_type state))
 
 
-  let rec solve_rigid : state:state -> Constraint.Rigid.t -> E.Equation.t list =
-    let open Constraint.Rigid in
+  let solve_rigid : state:state -> Constraint.Rigid.t -> E.Equation.t list =
     let open E.Equation in
     fun ~state rigid ->
-      match rigid with
-      | True -> []
-      | Conj rigids -> List.concat (List.map ~f:(solve_rigid ~state) rigids)
-      | Eq (t1, t2) ->
+      List.map rigid ~f:(fun (t1, t2) ->
         let t1 = of_type state t1 in
         let t2 = of_type state t2 in
-        [ t1 =%= t2 ]
+        t1 =%= t2)
+      
 
 
   (* 

--- a/src/constraints/solver/solver.ml
+++ b/src/constraints/solver/solver.ml
@@ -40,6 +40,9 @@ module Make (Algebra : Algebra) = struct
     let map t ~f () = f (t ())
     let both t1 t2 () = t1 (), t2 ()
     let list : type a. a t list -> a list t = fun ts () -> List.map ts ~f:run
+
+    let list_append : type a. a list t -> a list t -> a list t =
+      fun ts1 ts2 () -> ts1 () @ ts2 ()
   end
 
   (* Type reconstruction requires the notion of "decoding" the efficient graphical types
@@ -248,7 +251,7 @@ module Make (Algebra : Algebra) = struct
     let eq_modulo t t1 t2 = Equations.eq_modulo t.equations t1 t2
 
     (* let pp_equations t =  *)
-      (* Equations.pp t.equations *)
+    (* Equations.pp t.equations *)
   end
 
   let rec of_type state type_ =
@@ -272,7 +275,8 @@ module Make (Algebra : Algebra) = struct
         let t2 = of_type state t2 in
         [ t1 =%= t2 ]
 
-(* 
+
+  (* 
   let pp_type_explicit type_ =
     let rec pp_type_explicit type_ =
       match U.Type.get_structure type_ with
@@ -296,6 +300,21 @@ module Make (Algebra : Algebra) = struct
     Caml.Format.printf "\n";
     pp_type_explicit type_ *)
 
+  type 'a let_rec_poly_binding =
+    | Polymorphic of
+        { rigid_vars : Constraint.variable list
+        ; annotation_bindings : Constraint.Shallow_type.binding list
+        ; binding : Constraint.binding
+        ; in_ : 'a Constraint.t
+        }
+
+  type 'a let_rec_mono_binding =
+    | Monomorphic of
+        { rigid_vars : Constraint.variable list
+        ; flexible_vars : Constraint.Shallow_type.binding list
+        ; binding : Constraint.binding
+        ; in_ : 'a Constraint.t
+        }
 
   let rec solve
       : type a. state:state -> env:Env.t -> a Constraint.t -> a Elaborate.t
@@ -428,33 +447,113 @@ module Make (Algebra : Algebra) = struct
     Elaborate.list term_let_bindings, env
 
 
-  and solve_let_rec_bindings
+  and solve_let_rec_poly_bindings
       : type a.
         state:state
         -> env:Env.t
-        -> a Constraint.let_rec_binding list
+        -> a let_rec_poly_binding list
+        -> k:
+             (state:state
+              -> env:Env.t
+              -> a Constraint.term_let_rec_binding list Elaborate.t * Env.t)
         -> a Constraint.term_let_rec_binding list Elaborate.t * Env.t
     =
     let open Constraint in
-    fun ~state ~env bindings ->
+    (* Usage of continuation k is for an arbitrary context, used for the monomorphic bindings *)
+    fun ~state ~env let_rec_poly_bindings ~k ->
+      (* Compute the type schemes for the polymorphic bindings *)
+      let schemes =
+        List.map
+          let_rec_poly_bindings
+          ~f:(fun
+               (Polymorphic
+                 { rigid_vars; annotation_bindings; binding = _, a; _ })
+             ->
+            (* Enter a new region to generalize annotation *)
+            enter state;
+            (* Initialize rigid variables and the annotation *)
+            let rigid_vars = List.map ~f:(bind_rigid state) rigid_vars
+            and _annotation =
+              List.map ~f:(bind_flexible state) annotation_bindings
+            in
+            (* Lookup the bound type *)
+            let type_ = find state a in
+            (* Generalize and exit *)
+            let _generalizable, schemes =
+              exit state ~rigid_vars ~types:[ type_ ]
+            in
+            (* TODO: Add assertion here: ensure generalizable = rigid_vars *)
+            let scheme = List.hd_exn schemes in
+            scheme)
+      in
+      (* Extend environment that binds the recursive polymorphic bindings *)
+      let env, bindings =
+        List.fold2_exn
+          let_rec_poly_bindings
+          schemes
+          ~init:(env, [])
+          ~f:(fun (env, bindings) (Polymorphic { binding = x, _; _ }) scheme ->
+            Env.extend env x scheme, (x, scheme) :: bindings)
+      in
+      let term_let_mono_bindings, env = k ~state ~env in
+      (* We now assert the constraints in the polymorphic bindings *)
+      let values =
+        List.map
+          let_rec_poly_bindings
+          ~f:(fun (Polymorphic { in_; rigid_vars; annotation_bindings; _ }) ->
+            enter state;
+            let rigid_vars = List.map ~f:(bind_rigid state) rigid_vars
+            and _annotation_binding =
+              List.map ~f:(bind_flexible state) annotation_bindings
+            in
+            let value = solve ~state ~env in_ in
+            let generalizable, _ = exit state ~rigid_vars ~types:[] in
+            generalizable, value)
+      in
+      let make_term_let_rec_binding (var, scheme) (generalizable, value)
+          : _ term_let_rec_binding Elaborate.t
+        =
+       fun () ->
+        ( (var, Decoder.decode_scheme scheme)
+        , (List.map generalizable ~f:Decoder.decode_variable, value ()) )
+      in
+      ( Elaborate.list_append
+          (List.map2_exn bindings values ~f:make_term_let_rec_binding
+          |> Elaborate.list)
+          term_let_mono_bindings
+      , env )
+
+
+  and solve_let_rec_mono_bindings
+      : type a.
+        state:state
+        -> env:Env.t
+        -> a let_rec_mono_binding list
+        -> a Constraint.term_let_rec_binding list Elaborate.t * Env.t
+    =
+    let open Constraint in
+    fun ~state ~env let_rec_mono_bindings ->
       (* Enter a new region. *)
       enter state;
       (* Initialize the fresh flexible and rigid variables for each of the bindings. *)
       let _flexible_vars =
-        List.map bindings ~f:(fun (Let_rec_binding { flexible_vars; _ }) ->
-            flexible_vars)
+        List.map
+          let_rec_mono_bindings
+          ~f:(fun (Monomorphic { flexible_vars; _ }) -> flexible_vars)
         |> List.concat
         |> List.map ~f:(bind_flexible state)
       and rigid_vars =
-        List.map bindings ~f:(fun (Let_rec_binding { rigid_vars; _ }) ->
-            rigid_vars)
+        List.map
+          let_rec_mono_bindings
+          ~f:(fun (Monomorphic { rigid_vars; _ }) -> rigid_vars)
         |> List.concat
         |> List.map ~f:(bind_rigid state)
       in
       (* Convert the constraint types into graphical types. *)
       let types =
-        List.map bindings ~f:(fun (Let_rec_binding { binding = _, a; _ }) ->
-            find state a)
+        List.map
+          let_rec_mono_bindings
+          ~f:(fun (Monomorphic { binding = _, a; _ }) -> find state a)
       in
       (* The recursive environment binds the bindings from the [let_rec_bindings]. *)
       let rec_env =
@@ -462,25 +561,24 @@ module Make (Algebra : Algebra) = struct
           state
           env
           (List.map
-             ~f:(fun (Let_rec_binding { binding; _ }) -> binding)
-             bindings)
+             ~f:(fun (Monomorphic { binding; _ }) -> binding)
+             let_rec_mono_bindings)
       in
       (* Solve the values *)
       let values =
-        List.map bindings ~f:(fun (Let_rec_binding { in_; _ }) ->
+        List.map let_rec_mono_bindings ~f:(fun (Monomorphic { in_; _ }) ->
             solve ~state ~env:rec_env in_)
       in
       (* Generalize and exit *)
       let generalizable, schemes = exit state ~rigid_vars ~types in
       (* Compute extended environment and bindings. *)
       let env, bindings =
-        List.zip_exn bindings schemes
+        List.zip_exn let_rec_mono_bindings schemes
         |> List.fold_left
              ~init:(env, [])
-             ~f:(fun (env, bindings) (Let_rec_binding { binding = x, _; _ }, s)
-                -> Env.extend env x s, (x, s) :: bindings)
+             ~f:(fun (env, bindings) (Monomorphic { binding = x, _; _ }, s) ->
+               Env.extend env x s, (x, s) :: bindings)
       in
-      (* Helper function for constructing term let rec bindings. *)
       let make_term_let_rec_binding (var, scheme) value
           : _ term_let_rec_binding Elaborate.t
         =
@@ -492,6 +590,30 @@ module Make (Algebra : Algebra) = struct
       ( List.map2_exn bindings values ~f:make_term_let_rec_binding
         |> Elaborate.list
       , env )
+
+
+  and solve_let_rec_bindings
+      : type a.
+        state:state
+        -> env:Env.t
+        -> a Constraint.let_rec_binding list
+        -> a Constraint.term_let_rec_binding list Elaborate.t * Env.t
+    =
+    let open Constraint in
+    fun ~state ~env bindings ->
+      (* Partition bindings into polymorphic and monomorphic bindings *)
+      let mono, poly =
+        List.partition_map bindings ~f:(fun binding ->
+            match binding with
+            | Let_rec_mono_binding { rigid_vars; flexible_vars; binding; in_ }
+              ->
+              Either.First
+                (Monomorphic { rigid_vars; flexible_vars; binding; in_ })
+            | Let_rec_poly_binding { rigid_vars; annotation_bindings; binding; in_ } ->
+              Either.Second (Polymorphic { rigid_vars; annotation_bindings; binding; in_ }))
+      in
+      solve_let_rec_poly_bindings ~state ~env poly ~k:(fun ~state ~env ->
+          solve_let_rec_mono_bindings ~state ~env mono)
 
 
   type error =

--- a/src/constraints/solver/unifier.ml
+++ b/src/constraints/solver/unifier.ml
@@ -222,6 +222,7 @@ module Make (Former : Type_former.S) (Metadata : Metadata) :
      (of multi-equations). *)
 
   and unify_desc desc1 desc2 =
+    (* Caml.Format.printf "Unify: %d %d\n" (desc1.id) (desc2.id);     *)
     { id = desc1.id
     ; structure = unify_structure desc1.structure desc2.structure
     ; metadata = Metadata.merge desc1.metadata desc2.metadata

--- a/src/parsing/ast_types.ml
+++ b/src/parsing/ast_types.ml
@@ -20,7 +20,7 @@ type constant =
   | Const_int of int
   | Const_bool of bool
   | Const_unit
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 let string_of_constant constant =
   match constant with
@@ -35,7 +35,7 @@ type primitive =
   | Prim_div
   | Prim_mul
   | Prim_eq
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 let string_of_primitive primitive =
   match primitive with
@@ -49,7 +49,7 @@ let string_of_primitive primitive =
 type rec_flag =
   | Nonrecursive
   | Recursive
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 let string_of_rec_flag rec_flag =
   match rec_flag with

--- a/src/parsing/ast_types.ml
+++ b/src/parsing/ast_types.ml
@@ -46,16 +46,12 @@ let string_of_primitive primitive =
   | Prim_eq -> "(=)"
 
 
-type non_rec
-type rec_
-
-type 'a rec_flag =
-  | Nonrecursive : non_rec rec_flag
-  | Recursive : rec_ rec_flag
+type rec_flag =
+  | Nonrecursive
+  | Recursive
 [@@deriving sexp_of]
 
-let string_of_rec_flag : type a. a rec_flag -> string =
- fun rec_flag ->
+let string_of_rec_flag rec_flag =
   match rec_flag with
   | Nonrecursive -> "Nonrecursive"
   | Recursive -> "Recursive"

--- a/src/parsing/dune
+++ b/src/parsing/dune
@@ -1,5 +1,5 @@
 (library
  (public_name dromedary.parsing)
  (name parsing)
- (preprocess (pps ppx_jane))
+ (preprocess (pps ppx_jane ppx_deriving.eq))
  (libraries core dromedary.util))

--- a/src/parsing/parsetree.ml
+++ b/src/parsing/parsetree.ml
@@ -22,7 +22,7 @@ type core_type =
   | Ptyp_arrow of core_type * core_type
   | Ptyp_tuple of core_type list
   | Ptyp_constr of core_type list * string
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 type core_scheme = string list * core_type [@@deriving sexp_of]
 
@@ -35,7 +35,7 @@ type pattern =
   | Ppat_construct of string * (string list * pattern) option
   | Ppat_constraint of pattern * core_type
   | Ppat_coerce of pattern * core_type * core_type
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 type expression =
   | Pexp_var of string
@@ -54,7 +54,7 @@ type expression =
   | Pexp_match of expression * case list
   | Pexp_ifthenelse of expression * expression * expression
   | Pexp_coerce of expression * core_type * core_type
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 (** [P = E] *)
 and value_binding =

--- a/src/parsing/parsetree.ml
+++ b/src/parsing/parsetree.ml
@@ -42,8 +42,7 @@ type expression =
   | Pexp_const of constant
   | Pexp_fun of pattern * expression
   | Pexp_app of expression * expression
-  | Pexp_let of value_binding list * expression
-  | Pexp_let_rec of rec_value_binding list * expression
+  | Pexp_let of rec_flag * value_binding list * expression
   | Pexp_forall of string list * expression
   | Pexp_exists of string list * expression
   | Pexp_constraint of expression * core_type
@@ -58,14 +57,9 @@ type expression =
 
 (** [P = E] *)
 and value_binding =
-  { pvb_pat : pattern
+  { pvb_forall_vars : string list
+  ; pvb_pat : pattern
   ; pvb_expr : expression
-  }
-
-(** [x = E] *)
-and rec_value_binding =
-  { prvb_var : string
-  ; prvb_expr : expression
   }
 
 (** [P -> E]. *)
@@ -177,13 +171,9 @@ let rec pp_expression_mach ~indent ppf exp =
     print "Application";
     pp_expression_mach ~indent ppf exp1;
     pp_expression_mach ~indent ppf exp2
-  | Pexp_let (value_bindings, exp) ->
-    print "Let";
+  | Pexp_let (rec_flag, value_bindings, exp) ->
+    print ("Let" ^ string_of_rec_flag rec_flag);
     pp_value_bindings_mach ~indent ppf value_bindings;
-    pp_expression_mach ~indent ppf exp
-  | Pexp_let_rec (rec_value_bindings, exp) ->
-    print "Let rec";
-    pp_rec_value_bindings_mach ~indent ppf rec_value_bindings;
     pp_expression_mach ~indent ppf exp
   | Pexp_forall (variables, exp) ->
     print "Forall";
@@ -250,19 +240,6 @@ and pp_value_binding_mach ~indent ppf value_binding =
   pp_expression_mach ~indent ppf value_binding.pvb_expr
 
 
-and pp_rec_value_bindings_mach ~indent ppf rec_value_bindings =
-  Format.fprintf ppf "%sValue bindings:@." indent;
-  let indent = indent_space ^ indent in
-  List.iter ~f:(pp_rec_value_binding_mach ~indent ppf) rec_value_bindings
-
-
-and pp_rec_value_binding_mach ~indent ppf value_binding =
-  Format.fprintf ppf "%sValue binding:@." indent;
-  let indent = indent_space ^ indent in
-  Format.fprintf ppf "%sVariable: %s@." indent value_binding.prvb_var;
-  pp_expression_mach ~indent ppf value_binding.prvb_expr
-
-
 and pp_case_mach ~indent ppf case =
   Format.fprintf ppf "%sCase:@." indent;
   let indent = indent_space ^ indent in
@@ -283,10 +260,6 @@ let pp_expression_mach = to_pp_mach ~name:"Expression" ~pp:pp_expression_mach
 
 let pp_value_binding_mach =
   to_pp_mach ~name:"Balue binding" ~pp:pp_value_binding_mach
-
-
-let pp_rec_value_binding_mach =
-  to_pp_mach ~name:"Recursive value binding" ~pp:pp_rec_value_binding_mach
 
 
 let pp_case_mach = to_pp_mach ~name:"Case" ~pp:pp_case_mach
@@ -443,20 +416,17 @@ let rec pp_expression ppf exp =
     Format.fprintf ppf "@[fun@;%a->@;%a@]" pp_pattern pat pp_expression exp
   | Pexp_app (exp1, exp2) ->
     Format.fprintf ppf "@[%a@ %a@]" pp_expression exp1 pp_expression exp2
-  | Pexp_let (value_bindings, exp) ->
+  | Pexp_let (rec_flag, value_bindings, exp) ->
+    let flag =
+      match rec_flag with
+      | Nonrecursive -> ""
+      | Recursive -> "rec "
+    in
     Format.fprintf
       ppf
       "@[%a in@;%a@]"
-      (fun ppf -> pp_let_bindings ~pp:pp_value_binding ppf)
+      (fun ppf -> pp_let_bindings ~flag ~pp:pp_value_binding ppf)
       value_bindings
-      pp_expression
-      exp
-  | Pexp_let_rec (rec_value_bindings, exp) ->
-    Format.fprintf
-      ppf
-      "@[%a in@;%a@]"
-      (pp_let_bindings ~flag:"rec " ~pp:pp_rec_value_binding)
-      rec_value_bindings
       pp_expression
       exp
   | Pexp_forall (variables, exp) ->
@@ -548,15 +518,6 @@ and pp_value_binding ppf nonrec_value_binding =
   match pat with
   | Ppat_var x -> Format.fprintf ppf "@[%s@ %a@]" x pp_expression_function exp
   | _ -> Format.fprintf ppf "@[%a@;=@;%a@]" pp_pattern pat pp_expression exp
-
-
-and pp_rec_value_binding ppf rec_value_binding =
-  Format.fprintf
-    ppf
-    "@[%s@ %a@]"
-    rec_value_binding.prvb_var
-    pp_expression_function
-    rec_value_binding.prvb_expr
 
 
 and pp_case ppf case =

--- a/src/parsing/parsetree.mli
+++ b/src/parsing/parsetree.mli
@@ -27,7 +27,7 @@ type core_type =
   | Ptyp_constr of core_type list * string
       (** A type constructor (or "type former"), name "constr" is used for 
           consistency between OCaml and Dromedary code. *)
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 (** [pp_core_type_mach ppf core_type] pretty prints [core_type] in a "machine format" 
     (an explicit tree structure). *)
@@ -64,7 +64,7 @@ type pattern =
       (** [(P : T)]. *)
   | Ppat_coerce of pattern * core_type * core_type
       (** [(P : T :> T)] *)
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 val pp_pattern_mach : pattern Pretty_printer.t
 val pp_pattern : pattern Pretty_printer.t
@@ -110,7 +110,7 @@ type expression =
       (** If (or ternary) expressions [if E then E1 else E2]. *)
   | Pexp_coerce of expression * core_type * core_type
       (** [(E : T :> T)] *)
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 (** [P = E] *)
 and value_binding =
@@ -118,7 +118,7 @@ and value_binding =
   ; pvb_pat : pattern
   ; pvb_expr : expression
   }
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 
 (** [P -> E]. *)
@@ -126,7 +126,7 @@ and case =
   { pc_lhs : pattern
   ; pc_rhs : expression
   }
-[@@deriving sexp_of]
+[@@deriving sexp_of, eq]
 
 (** [pp_expression_mach ppf exp] pretty prints an expression [exp] as an explicit tree structure. *)
 val pp_expression_mach : expression Pretty_printer.t

--- a/src/parsing/parsetree.mli
+++ b/src/parsing/parsetree.mli
@@ -82,13 +82,9 @@ type expression =
       *)
   | Pexp_app of expression * expression 
       (** Function application [E1 E2]. *)
-  | Pexp_let of value_binding list * expression
+  | Pexp_let of rec_flag * value_binding list * expression
       (** Let expressions:
           [let P1 = E1 and ... and Pn = En in E]    
-      *)
-  | Pexp_let_rec of rec_value_binding list * expression
-      (** Recursive let expressions:
-          [let rec x1 = E1 and ... and xn = En in E]    
       *)
   | Pexp_forall of string list * expression
       (** Explicit "forall" quantifier [forall 'a1 ... 'an -> E]. 
@@ -115,17 +111,12 @@ type expression =
 
 (** [P = E] *)
 and value_binding =
-  { pvb_pat : pattern
+  { pvb_forall_vars : string list 
+  ; pvb_pat : pattern
   ; pvb_expr : expression
   }
 [@@deriving sexp_of]
 
-(** [x = E] *)
-and rec_value_binding =
-  { prvb_var : string
-  ; prvb_expr : expression
-  }
-[@@deriving sexp_of]
 
 (** [P -> E]. *)
 and case =
@@ -147,14 +138,6 @@ val pp_value_binding_mach : value_binding Pretty_printer.t
 (** [pp_value_binding ppf value_binding] pretty prints the value binding [value_bindings] as a 
     syntactic representation. *)
 val pp_value_binding : value_binding Pretty_printer.t
-
-(** [pp_rec_value_binding_mach ppf value_binding] pretty prints the recursive value binding [value_binding]
-    as an explicit tree. *)
-val pp_rec_value_binding_mach : rec_value_binding Pretty_printer.t
-
-(** [pp_rec_value_binding ppf value_binding] pretty prints the recursive value binding [value_bindings] as a 
-    syntactic representation. *)
-val pp_rec_value_binding : rec_value_binding Pretty_printer.t
 
 (** [pp_case_mach ppf case] pretty prints the case [case] as an explicit tree structure. *)
 val pp_case_mach : case Pretty_printer.t

--- a/src/parsing/parsetree.mli
+++ b/src/parsing/parsetree.mli
@@ -110,6 +110,7 @@ type expression =
       (** Match (or "case") expressions [match E with (P1 -> E1 | ... | Pn -> En)]. *)
   | Pexp_ifthenelse of expression * expression * expression
       (** If (or ternary) expressions [if E then E1 else E2]. *)
+  | Pexp_coerce of expression * core_type * core_type
 [@@deriving sexp_of]
 
 (** [P = E] *)

--- a/src/parsing/parsetree.mli
+++ b/src/parsing/parsetree.mli
@@ -58,10 +58,12 @@ type pattern =
       (** [c]. e.g. [1, true, ()]. *)
   | Ppat_tuple of pattern list 
       (** (P1, ..., Pn). Invariant n >= 2. *)
-  | Ppat_construct of string * pattern option 
+  | Ppat_construct of string * (string list * pattern) option 
       (** [C <P>]. *)
   | Ppat_constraint of pattern * core_type 
       (** [(P : T)]. *)
+  | Ppat_coerce of pattern * core_type * core_type
+      (** [(P : T :> T)] *)
 [@@deriving sexp_of]
 
 val pp_pattern_mach : pattern Pretty_printer.t
@@ -107,6 +109,7 @@ type expression =
   | Pexp_ifthenelse of expression * expression * expression
       (** If (or ternary) expressions [if E then E1 else E2]. *)
   | Pexp_coerce of expression * core_type * core_type
+      (** [(E : T :> T)] *)
 [@@deriving sexp_of]
 
 (** [P = E] *)

--- a/src/typing/coercion.ml
+++ b/src/typing/coercion.ml
@@ -1,0 +1,534 @@
+(*****************************************************************************)
+(*                                                                           *)
+(*                                Dromedary                                  *)
+(*                                                                           *)
+(*                Alistair O'Brien, University of Cambridge                  *)
+(*                                                                           *)
+(* Copyright 2021 Alistair O'Brien.                                          *)
+(*                                                                           *)
+(* All rights reserved. This file is distributed under the terms of the MIT  *)
+(* license, as described in the file LICENSE.                                *)
+(*                                                                           *)
+(*****************************************************************************)
+
+open! Import
+open Parsetree
+
+let rec free_variables_of_core_type core_type =
+  match core_type with
+  | Ptyp_var x -> String.Set.singleton x
+  | Ptyp_arrow (core_type1, core_type2) ->
+    String.Set.union
+      (free_variables_of_core_type core_type1)
+      (free_variables_of_core_type core_type2)
+  | Ptyp_constr (core_types, _) | Ptyp_tuple core_types ->
+    List.map ~f:free_variables_of_core_type core_types |> String.Set.union_list
+
+
+let occurs_check x core_type =
+  String.Set.mem (free_variables_of_core_type core_type) x
+
+
+module Equations = struct
+  type t =
+    { rigid_variables : String.Set.t
+    ; equations : (core_type * core_type) list
+    }
+  [@@deriving sexp_of]
+
+  let invariant t : unit =
+    Invariant.invariant [%here] t [%sexp_of: t] (fun () ->
+        (* Assert that all free variables of [t.equations] are bound in [t.rigid_variables] *)
+        assert (
+          List.map t.equations ~f:(fun (t1, t2) ->
+              String.Set.union
+                (free_variables_of_core_type t1)
+                (free_variables_of_core_type t2))
+          |> String.Set.union_list
+          |> String.Set.is_subset ~of_:t.rigid_variables);
+        (* Assert that all equations in [t.equations] are in solved form *)
+        assert (
+          List.for_all t.equations ~f:(function
+              | Ptyp_var _, _ | _, Ptyp_var _ -> true
+              | _ -> false));
+        (* Assert that equations are not cyclic. *)
+        assert (
+          List.for_all t.equations ~f:(function
+              | Ptyp_var _, Ptyp_var _ -> false
+              | Ptyp_var x, t | t, Ptyp_var x -> not (occurs_check x t)
+              | _ -> assert false)))
+
+
+  let empty = { rigid_variables = String.Set.empty; equations = [] }
+
+  let merge t1 t2 =
+    invariant t1;
+    invariant t2;
+    let t =
+      { rigid_variables = String.Set.union t1.rigid_variables t2.rigid_variables
+      ; equations = t1.equations @ t2.equations
+      }
+    in
+    invariant t;
+    t
+
+
+  let is_rigid_type t core_type =
+    let rec loop core_type =
+      match core_type with
+      | Ptyp_var x -> String.Set.mem t.rigid_variables x
+      | Ptyp_arrow (core_type1, core_type2) ->
+        loop core_type1 && loop core_type2
+      | Ptyp_constr (core_types, _) | Ptyp_tuple core_types ->
+        List.for_all core_types ~f:loop
+    in
+    loop core_type
+
+
+  (* Normalization ~>_E (from the paper) *)
+
+  module Normalization = struct
+    (* [compare_precision t1 t2] defines a total ordering on equations [t1 = t2]. *)
+    let compare_precision core_type1 core_type2 =
+      match core_type1, core_type2 with
+      | Ptyp_var x, Ptyp_var x' -> String.compare x x'
+      | Ptyp_var _, _ -> -1
+      | _, Ptyp_var _ -> 1
+      | _ -> assert false
+
+
+    (* [equivalence_class t core_type] returns the equivalence class descriptor
+       of [core_type] modulo the equations [t]. *)
+    let equivalence_class t core_type =
+      invariant t;
+      let max_by_precision = Base.Comparable.max compare_precision in
+      List.fold_left
+        t.equations
+        ~init:core_type
+        ~f:(fun equiv_class (core_type1, core_type2) ->
+          if equal_core_type core_type1 core_type
+          then max_by_precision core_type2 equiv_class
+          else if equal_core_type core_type2 core_type
+          then max_by_precision core_type1 equiv_class
+          else equiv_class)
+
+
+    let rec normalize t core_type =
+      invariant t;
+      match core_type with
+      | Ptyp_var _ ->
+        let equiv_class = equivalence_class t core_type in
+        if not (equal_core_type equiv_class core_type)
+        then normalize t equiv_class
+        else equiv_class
+      | Ptyp_arrow (core_type1, core_type2) ->
+        Ptyp_arrow (normalize t core_type1, normalize t core_type2)
+      | Ptyp_constr (core_types, constr) ->
+        Ptyp_constr (List.map core_types ~f:(normalize t), constr)
+      | Ptyp_tuple core_types ->
+        Ptyp_tuple (List.map core_types ~f:(normalize t))
+  end
+
+  let normalize = Normalization.normalize
+
+  let is_equivalent t core_type1 core_type2 =
+    invariant t;
+    let normalize = normalize t in
+    let ( =% ) core_type1 core_type2 =
+      equal_core_type core_type1 core_type2
+      || equal_core_type (normalize core_type1) (normalize core_type2)
+    in
+    let rec loop core_type1 core_type2 =
+      match core_type1, core_type2 with
+      | ( Ptyp_arrow (core_type11, core_type12)
+        , Ptyp_arrow (core_type21, core_type22) ) ->
+        loop core_type11 core_type21 && loop core_type12 core_type22
+      | Ptyp_constr (core_types1, constr1), Ptyp_constr (core_types2, constr2)
+        ->
+        if String.equal constr1 constr2
+        then (
+          match List.for_all2 core_types1 core_types2 ~f:loop with
+          | Ok result -> result
+          | Unequal_lengths -> false)
+        else false
+      | Ptyp_tuple core_types1, Ptyp_tuple core_types2 ->
+        (match List.for_all2 core_types1 core_types2 ~f:loop with
+        | Ok result -> result
+        | Unequal_lengths -> false)
+      | _, _ -> core_type1 =% core_type2
+    in
+    loop core_type1 core_type2
+
+
+  exception Inconsistent
+
+  let rec add_equation t (core_type1, core_type2) =
+    invariant t;
+    let t =
+      match core_type1, core_type2 with
+      | ( Ptyp_arrow (core_type11, core_type12)
+        , Ptyp_arrow (core_type21, core_type22) ) ->
+        add_equation
+          (add_equation t (core_type11, core_type21))
+          (core_type12, core_type22)
+      | Ptyp_constr (core_types1, constr1), Ptyp_constr (core_types2, constr2)
+        ->
+        if String.equal constr1 constr2
+        then (
+          match
+            List.fold2
+              core_types1
+              core_types2
+              ~init:t
+              ~f:(fun t core_type1 core_type2 ->
+                add_equation t (core_type1, core_type2))
+          with
+          | Ok t -> t
+          | Unequal_lengths -> raise Inconsistent)
+        else raise Inconsistent
+      | Ptyp_tuple core_types1, Ptyp_tuple core_types2 ->
+        (match
+           List.fold2
+             core_types1
+             core_types2
+             ~init:t
+             ~f:(fun t core_type1 core_type2 ->
+               add_equation t (core_type1, core_type2))
+         with
+        | Ok t -> t
+        | Unequal_lengths -> raise Inconsistent)
+      | _, _ ->
+        if (not (is_equivalent t core_type1 core_type2))
+           && is_rigid_type t core_type1
+           && is_rigid_type t core_type2
+        then (
+          let core_type1 = Normalization.normalize t core_type1
+          and core_type2 = Normalization.normalize t core_type2 in
+          if match core_type1, core_type2 with
+             (* Fails occurs check *)
+             | Ptyp_var x, core_type | core_type, Ptyp_var x ->
+               occurs_check x core_type
+             (* Not in equational form! *)
+             | _ -> true
+          then raise Inconsistent;
+          { t with equations = (core_type1, core_type2) :: t.equations })
+        else t
+    in
+    invariant t;
+    t
+
+
+  let add_rigid_variables t rigid_variables =
+    invariant t;
+    let t =
+      { t with
+        rigid_variables = String.Set.union rigid_variables t.rigid_variables
+      }
+    in
+    invariant t;
+    t
+
+
+  let rigid_variables t = t.rigid_variables
+  let is_rigid_variable t x = String.Set.mem t.rigid_variables x
+  let equations t = t.equations
+end
+
+let fresh_variable =
+  let next = ref 0 in
+  fun () ->
+    let variable = !next in
+    next := !next + 1;
+    "_" ^ Int.to_string variable
+
+
+(* Shapes (from the paper) *)
+
+module Shape = struct
+  type t = string list * core_type [@@deriving sexp_of]
+
+  let invariant equations ((flexible_variables, core_type) as t) : unit =
+    Invariant.invariant [%here] t [%sexp_of: t] (fun () ->
+        Equations.invariant equations;
+        let flexible_variables = String.Set.of_list flexible_variables in
+        let rigid_variables = Equations.rigid_variables equations in
+        (* Assert that [flexible_variables] and rigid variables of [equations] are disjoint. *)
+        assert (String.Set.are_disjoint flexible_variables rigid_variables);
+        (* Assert thart free variables of [core_type] are in [flexibile_variables or rigid_variables]. *)
+        assert (
+          free_variables_of_core_type core_type
+          |> String.Set.is_subset
+               ~of_:(String.Set.union flexible_variables rigid_variables)))
+
+
+  let equal (_, core_type1) (_, core_type2) =
+    equal_core_type core_type1 core_type2
+
+
+  let is_equivalent equations ((_, core_type1) as t1) ((_, core_type2) as t2) =
+    invariant equations t1;
+    invariant equations t2;
+    Equations.is_equivalent equations core_type1 core_type2
+
+
+  let bottom () =
+    let x = fresh_variable () in
+    [ x ], Ptyp_var x
+
+
+  let normalize equations ((flexible_variables, core_type) as t) =
+    invariant equations t;
+    let t = flexible_variables, Equations.normalize equations core_type in
+    invariant equations t;
+    t
+end
+
+module Unifier = struct
+  module Substitution = struct
+    type t = core_type String.Map.t
+
+    let empty = String.Map.empty
+
+    let find t x =
+      match String.Map.find t x with
+      | Some core_type -> core_type
+      | None -> Ptyp_var x
+
+
+    let singleton = String.Map.singleton
+    let merge t1 t2 = Map.merge_skewed t1 t2 ~combine:(fun ~key:_ _ x -> x)
+
+    (* These functions don't really belong here... but this is a prototype (and unlikely to be used) *)
+    let rec apply t core_type =
+      match core_type with
+      | Ptyp_var x -> find t x
+      | Ptyp_arrow (core_type1, core_type2) ->
+        Ptyp_arrow (apply t core_type1, apply t core_type2)
+      | Ptyp_constr (core_types, constr) ->
+        Ptyp_constr (List.map ~f:(apply t) core_types, constr)
+      | Ptyp_tuple core_types -> Ptyp_tuple (List.map ~f:(apply t) core_types)
+
+
+    let compose t1 t2 = merge (Map.map t2 ~f:(apply t1)) t1
+
+    let rename_shape (vars, core_type) =
+      let alist = List.map vars ~f:(fun x -> x, fresh_variable ()) in
+      let t =
+        String.Map.of_alist_exn
+          (List.map ~f:(fun (x, x') -> x, Ptyp_var x') alist)
+      in
+      List.map ~f:snd alist, apply t core_type
+
+
+    let close_shape equations (_flexible_variables, core_type) =
+      let flexible_variables =
+        String.Set.diff
+          (free_variables_of_core_type core_type)
+          (Equations.rigid_variables equations)
+      in
+      rename_shape (String.Set.to_list flexible_variables, core_type)
+
+
+    let apply_shape equations t (flexible_variables, core_type) =
+      close_shape equations (flexible_variables, apply t core_type)
+  end
+
+  let unify equations core_type1 core_type2 =
+    Equations.invariant equations;
+    let is_rigid_variable x = Equations.is_rigid_variable equations x in
+    let rec loop core_type1 core_type2 =
+      if Equations.is_equivalent equations core_type1 core_type2
+      then Substitution.empty
+      else (
+        match core_type1, core_type2 with
+        | Ptyp_var x1, Ptyp_var x2 ->
+          if is_rigid_variable x1 && is_rigid_variable x2
+          then
+            raise_s [%message "Coercion: Cannot unify distinct rigid variables"]
+          else
+            Substitution.merge
+              (if is_rigid_variable x1
+              then Substitution.empty
+              else Substitution.singleton x1 core_type2)
+              (if is_rigid_variable x2
+              then Substitution.empty
+              else Substitution.singleton x2 core_type1)
+        | (Ptyp_var x, core_type | core_type, Ptyp_var x)
+          when not (is_rigid_variable x || occurs_check x core_type1) ->
+          Substitution.singleton x core_type
+        | ( Ptyp_arrow (core_type11, core_type12)
+          , Ptyp_arrow (core_type21, core_type22) ) ->
+          let subst1 = loop core_type11 core_type21 in
+          let subst2 =
+            loop
+              (Substitution.apply subst1 core_type12)
+              (Substitution.apply subst1 core_type22)
+          in
+          Substitution.compose subst2 subst1
+        | Ptyp_constr (core_types1, constr1), Ptyp_constr (core_types2, constr2)
+          when String.equal constr1 constr2 ->
+          let subst =
+            List.fold2
+              core_types1
+              core_types2
+              ~init:Substitution.empty
+              ~f:(fun subst core_type1 core_type2 ->
+                Substitution.compose
+                  (loop
+                     (Substitution.apply subst core_type1)
+                     (Substitution.apply subst core_type2))
+                  subst)
+          in
+          (match subst with
+          | Ok subst -> subst
+          | Unequal_lengths ->
+            raise_s
+              [%message "Coercion: Cannot unify constructors of unequal arity"])
+        | Ptyp_tuple core_types1, Ptyp_tuple core_types2 ->
+          let subst =
+            List.fold2
+              core_types1
+              core_types2
+              ~init:Substitution.empty
+              ~f:(fun subst core_type1 core_type2 ->
+                Substitution.compose
+                  (loop
+                     (Substitution.apply subst core_type1)
+                     (Substitution.apply subst core_type2))
+                  subst)
+          in
+          (match subst with
+          | Ok subst -> subst
+          | Unequal_lengths ->
+            raise_s
+              [%message "Coercion: Cannot unify tuple types of unequal length"])
+        | _, _ -> raise_s [%message "Coercion: Cannot unify!"])
+    in
+    loop core_type1 core_type2
+
+
+  let unify_shape
+      equations
+      ((_, core_type1) as shape1)
+      ((_, core_type2) as shape2)
+    =
+    Equations.invariant equations;
+    Shape.invariant equations shape1;
+    Shape.invariant equations shape2;
+    unify equations core_type1 core_type2
+
+
+  let lub equations core_type1 core_type2 =
+    let subst = unify equations core_type1 core_type2 in
+    Substitution.apply subst core_type1
+
+
+  let lub_shape equations shape1 shape2 =
+    let subst = unify_shape equations shape1 shape2 in
+    Substitution.apply_shape equations subst shape1
+end
+
+(* Pruning (from the paper) *)
+
+let has_lub equations core_type1 core_type2 =
+  try
+    ignore (Unifier.lub equations core_type1 core_type2 : core_type);
+    true
+  with
+  | _ -> false
+
+
+let denotation equations core_type =
+  List.fold_left
+    (Equations.equations equations)
+    ~init:[]
+    ~f:(fun denotation (t1, t2) ->
+      if has_lub equations core_type t1 || has_lub equations core_type t2
+      then t1 :: t2 :: denotation
+      else denotation)
+
+
+let prune equations1 equations2 (_, core_type) =
+  let rec loop core_type =
+    (* Compute denotations under each set of equations *)
+    let denotation1 = denotation equations1 core_type
+    and denotation2 = denotation equations2 core_type in
+    (* Determine whether [denotation1 >= denotation2], if so, then 
+       we iterate (as we need the lub) *)
+    if List.for_all ~f:(List.mem ~equal:equal_core_type denotation1) denotation2
+    then (
+      match core_type with
+      | Ptyp_var x -> Ptyp_var x
+      | Ptyp_arrow (t1, t2) -> Ptyp_arrow (loop t1, loop t2)
+      | Ptyp_constr (ts, constr) -> Ptyp_constr (List.map ~f:loop ts, constr)
+      | Ptyp_tuple ts ->
+        Ptyp_tuple (List.map ~f:loop ts)
+        (* Otherwise, we loose information, and return the most general type (a flexible variable) *))
+    else Ptyp_var (fresh_variable ())
+  in
+  loop core_type
+
+
+(* IBIS *)
+
+open Ast_types
+open Types
+
+let infer_constant const : Shape.t =
+  match const with
+  | Const_int _ -> [], Ptyp_constr ([], "int")
+  | Const_bool _ -> [], Ptyp_constr ([], "bool")
+  | Const_unit -> [], Ptyp_constr ([], "unit")
+
+
+let rec infer_fragment ~env ~equations pat pat_shape =
+  match pat with
+  | Ppat_any -> Ppat_any, ([], equations, String.Map.empty)
+  | Ppat_var x -> Ppat_var x, ([], equations, String.Map.singleton x pat_shape)
+  | Ppat_const const ->
+    ignore
+      (Unifier.unify_shape equations pat_shape (infer_constant const)
+        : core_type String.Map.t);
+    Ppat_const const, ([], equations, String.Map.empty)
+  | Ppat_alias (pat, x) ->
+    let pat, (betas, equations, bindings) =
+      infer_fragment ~env ~equations pat pat_shape
+    in
+    ( Ppat_alias (pat, x)
+    , (betas, equations, String.Map.add_exn bindings ~key:x ~data:pat_shape) )
+  | Ppat_constraint (pat, pat_shape') ->
+    let pat_shape' = Shape.normalize equations pat_shape' in
+    let pat, fragment =
+      infer_fragment
+        ~env
+        ~equations
+        pat
+        (lub_shape equations pat_shape pat_shape')
+    in
+    Ppat_constraint (pat, pat_shape'), fragment
+  (* | Ppat_coerce (_pat, _pat_type1, _pat_type2) -> assert false
+  | Ppat_tuple pats -> assert false
+  | Ppat_construct (constr, pat_arg) ->
+    let constr_alphas, constr_arg, constr_type, constr_constraints =
+      inst_constr_decl constr
+    in
+    (* Check [pat_shape] unifies w/ [constr_type] *)
+    let subst = Unifier.unify equations constr_type (Shape.to_type pat_shape) in
+    (match pat_arg, constr_arg with
+    | ( Some (betas, pat_arg)
+      , Some
+          { constructor_arg_betas = constr_betas
+          ; constructor_arg_type = constr_arg
+          } ) ->
+      (* Construct new equation theory *)
+      let equations = Equations.add_equation Equation.add_rigid_variables in
+      assert false
+    | None, None ->
+      let equations =
+        List.fold_left
+          (Substitution.apply_constraints subst constr_constraints)
+          ~init:equations
+          ~f:Equations.add_equation
+      in
+      Ppat_construct (constr, None), ([], equations, String.Map.empty)
+    | _, _ -> raise_s [%message "Pattern constructor argument mistmatch"]) *)

--- a/src/typing/computation.ml
+++ b/src/typing/computation.ml
@@ -195,6 +195,8 @@ module Fragment = struct
     ; term_bindings :
         (String.t, Constraint.variable, String.comparator_witness) Map.t
     ; local_constraint : Constraint.Rigid.t
+    ; substitution :
+        (String.t, Constraint.variable, String.comparator_witness) Map.t
     }
 
   let empty =
@@ -202,17 +204,19 @@ module Fragment = struct
     ; existential_bindings = []
     ; term_bindings = Map.empty (module String)
     ; local_constraint = Rigid.true_
+    ; substitution = Map.empty (module String)
     }
 
 
   let merge t1 t2 =
-    let exception Duplicate of string in
+    let exception Duplicate_term_var of string in
+    let exception Duplicate_type_var of string in
     try
       let term_bindings =
         Map.merge_skewed
           t1.term_bindings
           t2.term_bindings
-          ~combine:(fun ~key _ _ -> raise (Duplicate key))
+          ~combine:(fun ~key _ _ -> raise (Duplicate_term_var key))
       in
       let universal_variables =
         t1.universal_variables @ t2.universal_variables
@@ -221,16 +225,24 @@ module Fragment = struct
         t1.existential_bindings @ t2.existential_bindings
       in
       let local_constraint =
-        Rigid.conj t1.local_constraint t2.local_constraint
+        Rigid.and_ t1.local_constraint t2.local_constraint
+      in
+      let substitution =
+        Map.merge_skewed
+          t1.substitution
+          t2.substitution
+          ~combine:(fun ~key _ _ -> raise (Duplicate_type_var key))
       in
       Ok
         { universal_variables
         ; existential_bindings
         ; term_bindings
         ; local_constraint
+        ; substitution
         }
     with
-    | Duplicate term_var -> Error (`Duplicate_term_var term_var)
+    | Duplicate_term_var term_var -> Error (`Duplicate_term_var term_var)
+    | Duplicate_type_var var -> Error (`Duplicate_type_var var)
 
 
   let of_existential_bindings existential_bindings =
@@ -245,7 +257,8 @@ module Fragment = struct
     ( t.universal_variables
     , t.existential_bindings
     , t.local_constraint
-    , t.term_bindings |> Map.to_alist |> List.map ~f:(fun (x, a) -> x #= a) )
+    , t.term_bindings |> Map.to_alist |> List.map ~f:(fun (x, a) -> x #= a)
+    , Substitution.of_map t.substitution )
 end
 
 module Pattern = struct
@@ -293,9 +306,12 @@ module Pattern = struct
 
   let write fragment : unit t = fun _input -> Ok (fragment, ())
   let extend x a = write (Fragment.of_term_binding x a)
+  let assert_ local_constraint = write Fragment.{ empty with local_constraint }
 
-  let assert_ local_constraint = 
-    write Fragment.{ empty with local_constraint }
+  let extend_fragment_substitution substitution =
+    write
+      Fragment.{ empty with substitution = Substitution.to_map substitution }
+
 
   module Binder = struct
     include Computation
@@ -310,10 +326,11 @@ module Pattern = struct
 
     let forall () =
       let var = Constraint.fresh () in
-      let%bind.Computation () = 
+      let%bind.Computation () =
         write Fragment.{ empty with universal_variables = [ var ] }
       in
       return var
+
 
     let exists_bindings bindings =
       write (Fragment.of_existential_bindings bindings)
@@ -323,7 +340,7 @@ module Pattern = struct
 
     let forall_vars vars =
       write Fragment.{ empty with universal_variables = vars }
-      
+
 
     let of_type type_ =
       let bindings, var = Constraint.Shallow_type.of_type type_ in

--- a/src/typing/computation.ml
+++ b/src/typing/computation.ml
@@ -190,13 +190,19 @@ module Fragment = struct
   open Constraint
 
   type t =
-    { existential_bindings : Shallow_type.binding list
+    { universal_variables : variable list
+    ; existential_bindings : Shallow_type.binding list
     ; term_bindings :
         (String.t, Constraint.variable, String.comparator_witness) Map.t
+    ; local_constraint : Constraint.Rigid.t
     }
 
   let empty =
-    { existential_bindings = []; term_bindings = Map.empty (module String) }
+    { universal_variables = []
+    ; existential_bindings = []
+    ; term_bindings = Map.empty (module String)
+    ; local_constraint = Rigid.true_
+    }
 
 
   let merge t1 t2 =
@@ -208,26 +214,37 @@ module Fragment = struct
           t2.term_bindings
           ~combine:(fun ~key _ _ -> raise (Duplicate key))
       in
+      let universal_variables =
+        t1.universal_variables @ t2.universal_variables
+      in
       let existential_bindings =
         t1.existential_bindings @ t2.existential_bindings
       in
-      Ok { existential_bindings; term_bindings }
+      let local_constraint =
+        Rigid.conj t1.local_constraint t2.local_constraint
+      in
+      Ok
+        { universal_variables
+        ; existential_bindings
+        ; term_bindings
+        ; local_constraint
+        }
     with
     | Duplicate term_var -> Error (`Duplicate_term_var term_var)
 
 
   let of_existential_bindings existential_bindings =
-    { existential_bindings; term_bindings = Map.empty (module String) }
+    { empty with existential_bindings }
 
 
   let of_term_binding x a =
-    { existential_bindings = []
-    ; term_bindings = Map.singleton (module String) x a
-    }
+    { empty with term_bindings = Map.singleton (module String) x a }
 
 
   let to_bindings t =
-    ( t.existential_bindings
+    ( t.universal_variables
+    , t.existential_bindings
+    , t.local_constraint
     , t.term_bindings |> Map.to_alist |> List.map ~f:(fun (x, a) -> x #= a) )
 end
 
@@ -277,6 +294,9 @@ module Pattern = struct
   let write fragment : unit t = fun _input -> Ok (fragment, ())
   let extend x a = write (Fragment.of_term_binding x a)
 
+  let assert_ local_constraint = 
+    write Fragment.{ empty with local_constraint }
+
   module Binder = struct
     include Computation
 
@@ -289,10 +309,11 @@ module Pattern = struct
 
 
     let forall () =
-      fail
-        [%message
-          "Cannot bind a universal variable in a pattern binding context."]
-
+      let var = Constraint.fresh () in
+      let%bind.Computation () = 
+        write Fragment.{ empty with universal_variables = [ var ] }
+      in
+      return var
 
     let exists_bindings bindings =
       write (Fragment.of_existential_bindings bindings)
@@ -300,11 +321,9 @@ module Pattern = struct
 
     let exists_vars vars = exists_bindings (List.map ~f:(fun x -> x, None) vars)
 
-    let forall_vars _vars =
-      fail
-        [%message
-          "Cannot bind a universal variable in a pattern binding context."]
-
+    let forall_vars vars =
+      write Fragment.{ empty with universal_variables = vars }
+      
 
     let of_type type_ =
       let bindings, var = Constraint.Shallow_type.of_type type_ in

--- a/src/typing/computation_intf.ml
+++ b/src/typing/computation_intf.ml
@@ -186,6 +186,7 @@ module type Intf = sig
          * Shallow_type.binding list
          * Constraint.Rigid.t
          * binding list
+         * Substitution.t
   end
 
   module Pattern : sig
@@ -194,6 +195,8 @@ module type Intf = sig
     val write : Fragment.t -> unit t
     val extend : string -> Constraint.variable -> unit t
     val assert_ : Constraint.Rigid.t -> unit t
+    val extend_fragment_substitution : Substitution.t -> unit t
+
     val run : 'a t -> (Fragment.t * 'a) Expression.t
   end
 end

--- a/src/typing/computation_intf.ml
+++ b/src/typing/computation_intf.ml
@@ -114,6 +114,8 @@ module type S = sig
     val exists_bindings : Constraint.Shallow_type.binding list -> unit t
     val of_type : Constraint.Type.t -> Constraint.variable t
 
+    (* val implies : Constraint.Rigid.t -> unit t *)
+
     module Let_syntax : sig
       val return : 'a -> 'a t
       val ( let& ) : 'a computation -> ('a -> 'b t) -> 'b t
@@ -178,7 +180,12 @@ module type Intf = sig
 
     type t
 
-    val to_bindings : t -> Shallow_type.binding list * binding list
+    val to_bindings
+      :  t
+      -> variable list
+         * Shallow_type.binding list
+         * Constraint.Rigid.t
+         * binding list
   end
 
   module Pattern : sig
@@ -186,6 +193,7 @@ module type Intf = sig
 
     val write : Fragment.t -> unit t
     val extend : string -> Constraint.variable -> unit t
+    val assert_ : Constraint.Rigid.t -> unit t
     val run : 'a t -> (Fragment.t * 'a) Expression.t
   end
 end

--- a/src/typing/env.ml
+++ b/src/typing/env.ml
@@ -45,15 +45,9 @@ let add_type_decl t type_decl =
     match type_decl.type_kind with
     | Type_record label_decls ->
       List.fold_left label_decls ~init:t ~f:(fun t label_decl ->
-          [%test_eq: string list]
-            label_decl.label_type_params
-            type_decl.type_params;
           add_label_decl t label_decl)
     | Type_variant constr_decls ->
       List.fold_left constr_decls ~init:t ~f:(fun t constr_decl ->
-          [%test_eq: string list]
-            constr_decl.constructor_type_params
-            type_decl.type_params;
           add_constr_decl t constr_decl)
   in
   { t with types = Map.set t.types ~key:type_decl.type_name ~data:type_decl }

--- a/src/typing/infer.ml
+++ b/src/typing/infer.ml
@@ -116,37 +116,80 @@ let make_constr_desc constr_name constr_arg constr_type
   }
 
 
+(* [substitution_of_vars vars] returns a substitution w/ 
+   domain [vars] bound to fresh variables. *)
+let substitution_of_vars vars =
+  Substitution.of_alist (List.map ~f:(fun x -> x, fresh ()) vars)
+
+
+(* [inst_constr_decl ~env constr] instantiates a constructor declaration w/ constructor name [constr] *)
 let inst_constr_decl ~env name
-    : (Constraint.variable list * Type.t option * Type.t, _) Result.t
+    : ( variable list
+        * (variable list * Type.t) option
+        * Type.t
+        * Constraint.Rigid.t
+    , _ ) Result.t
   =
   let open Result in
   let open Let_syntax in
-  (* Determine the constructor argument and type parameters using
+  (* Determine the constructor argument, type and alphas using
      the environment [env] and the constructor name [name]. *)
   let%bind { constructor_arg = constr_arg
            ; constructor_type = constr_type
-           ; constructor_type_params = constr_type_params
+           ; constructor_alphas = constr_alphas
+           ; constructor_constraints = constr_constraints
            ; _
            }
     =
     Env.find_constr env name
   in
-  (* Compute a fresh set of existential variables *)
-  let%bind substitution =
-    Substitution.of_alist
-      (List.map ~f:(fun x -> x, fresh ()) constr_type_params)
+  (* Redefined due to repeated error function *)
+  let substitution_of_vars vars =
+    substitution_of_vars vars
     |> Result.map_error ~f:(fun (`Duplicate_type_variable var) ->
            `Duplicate_type_parameter_for_constructor (name, var))
   in
-  (* Compute the inferred type using the existential variables. *)
-  let%bind constr_arg =
-    match constr_arg with
-    | Some constr_arg ->
-      convert_type_expr ~substitution constr_arg >>| Option.some
-    | None -> return None
-  in
+  (* Compute fresh set of variables for [constr_alphas]. *)
+  let%bind substitution = substitution_of_vars constr_alphas in
+  let alphas = Substitution.rng substitution in
+  (* Compute the constructor (return) type. *)
   let%bind constr_type = convert_type_expr ~substitution constr_type in
-  return (Substitution.rng substitution, constr_arg, constr_type)
+  (* Compute the constructor argument. *)
+  let%bind constr_arg, substitution =
+    match constr_arg with
+    | Some
+        { constructor_arg_betas = constr_betas
+        ; constructor_arg_type = constr_arg
+        } ->
+      (* Assert that constr_betas and constr_alphas have no intersection. *)
+      let%bind () =
+        match
+          List.find ~f:(List.mem ~equal:String.equal constr_betas) constr_alphas
+        with
+        | Some var ->
+          fail (`Duplicate_type_parameter_for_constructor (name, var))
+        | None -> return ()
+      in
+      (* Compute fresh set of variables for [constr_betas]. *)
+      let%bind substitution' = substitution_of_vars constr_betas in
+      let betas = Substitution.rng substitution' in
+      (* Compute the type for the [constr_arg]. *)
+      let substitution = Substitution.merge substitution substitution' in
+      let%bind constr_arg = convert_type_expr ~substitution constr_arg in
+      (* Return the constructor argument and modified substitution, used for constraints. *)
+      return (Some (betas, constr_arg), substitution)
+    | None -> return (None, substitution)
+  in
+  (* Compute the converted type constraints. *)
+  let%bind constr_constraint =
+    List.map constr_constraints ~f:(fun (type1, type2) ->
+        let%bind type1 = convert_type_expr ~substitution type1 in
+        let%bind type2 = convert_type_expr ~substitution type2 in
+        return (type1, type2))
+    |> Result.all
+    >>| Rigid.of_equations
+  in
+  return (alphas, constr_arg, constr_type, constr_constraint)
 
 
 let inst_label_decl ~env label
@@ -177,6 +220,48 @@ let make_label_desc label_name label_arg label_type
   { label_name; label_type; label_arg }
 
 
+(* [is_constr_generalized ~enc constr] returns whether the constructor [constr] is a constructor of a GADT *)
+let is_constr_generalized ~env constr : (bool, _) Result.t =
+  let open Result.Let_syntax in
+  let%map { constructor_constraints; _ } = Env.find_constr env constr in
+  not (List.is_empty constructor_constraints)
+
+
+(* [is_pat_generalized ~env pat] returns whether the pattern [pat] contains a generalized constructor *)
+let rec is_pat_generalized ~env pat : (bool, _) Result.t =
+  let open Result.Let_syntax in
+  match pat with
+  | Ppat_construct (constr, pat) ->
+    if%bind is_constr_generalized ~env constr
+    then return true
+    else (
+      match pat with
+      | Some pat -> is_pat_generalized ~env pat
+      | None -> return false)
+  | Ppat_tuple pats ->
+    let%map is_pats_generalized =
+      List.map pats ~f:(is_pat_generalized ~env) |> Result.all
+    in
+    List.exists ~f:Fn.id is_pats_generalized
+  | Ppat_constraint (pat, _) | Ppat_alias (pat, _) ->
+    is_pat_generalized ~env pat
+  | Ppat_const _ | Ppat_any | Ppat_var _ -> return false
+
+
+(* [is_case_generalized ~env case] returns whether the case pattern contains a generalized pattern. *)
+let is_case_generalized ~env case : (bool, _) Result.t =
+  is_pat_generalized ~env case.pc_lhs
+
+
+(* [is_case_generalized ~env cases] returns whether the cases contains a generalized case. *)
+let is_cases_generalized ~env cases : (bool, _) Result.t =
+  let open Result.Let_syntax in
+  let%map is_cases_generalized =
+    List.map cases ~f:(is_case_generalized ~env) |> Result.all
+  in
+  List.exists ~f:Fn.id is_cases_generalized
+
+
 module Pattern = struct
   module Computation = Computation.Pattern
   open Computation.Binder
@@ -193,9 +278,11 @@ module Pattern = struct
             (var : string)])
 
 
-  let inst_constr_decl name : (Type.t option * Type.t) Binder.t =
+  let inst_constr_decl name
+      : ((variable list * Type.t) option * Type.t * Constraint.Rigid.t) Binder.t
+    =
     let open Binder.Let_syntax in
-    let& vars, constr_arg, constr_type =
+    let& alphas, constr_arg, constr_type, constr_constraint =
       let%bind.Computation env = env in
       of_result (inst_constr_decl ~env name) ~message:(function
           | `Duplicate_type_parameter_for_constructor (constr, var) ->
@@ -216,20 +303,26 @@ module Pattern = struct
                occur! Good luck)"
                 (var : string)])
     in
-    let%bind () = exists_vars vars in
-    return (constr_arg, constr_type)
+    let%bind () = exists_vars alphas in
+    return (constr_arg, constr_type, constr_constraint)
 
 
   let infer_constr constr_name constr_type
-      : (constructor_description Constraint.t * variable option) Binder.t
+      : (constructor_description Constraint.t
+        * variable option
+        * Constraint.Rigid.t)
+      Binder.t
     =
     let open Binder.Let_syntax in
     (* Instantiate the constructor description. *)
-    let%bind constr_arg, constr_type' = inst_constr_decl constr_name in
+    let%bind constr_arg, constr_type', constr_constraint =
+      inst_constr_decl constr_name
+    in
     (* Convert [const_arg] and [const_type'] to variables *)
     let%bind constr_arg =
       match constr_arg with
-      | Some constr_arg ->
+      | Some (constr_betas, constr_arg) ->
+        let%bind () = forall_vars constr_betas in
         let%bind constr_arg = of_type constr_arg in
         return (Some constr_arg)
       | None -> return None
@@ -241,7 +334,7 @@ module Pattern = struct
       =~ constr_type'
       >> make_constr_desc constr_name constr_arg constr_type
     in
-    return (constr_desc, constr_arg)
+    return (constr_desc, constr_arg, constr_constraint)
 
 
   let infer pat pat_type =
@@ -279,19 +372,11 @@ module Pattern = struct
           (let%map () = pat_type =~= tuple vars
            and pats = pats in
            Tpat_tuple pats)
-      | Ppat_constraint (pat, pat_type') ->
-        let@ pat_type' =
-          let open Binder.Let_syntax in
-          let& pat_type' = convert_core_type pat_type' in
-          of_type pat_type'
-        in
-        let%bind pat_desc = infer_pat_desc pat pat_type' in
-        return
-          (let%map () = pat_type =~ pat_type'
-           and pat_desc = pat_desc in
-           pat_desc)
       | Ppat_construct (constr, arg_pat) ->
-        let@ constr_desc, arg_pat_type = infer_constr constr pat_type in
+        let@ constr_desc, arg_pat_type, constr_constraint =
+          infer_constr constr pat_type
+        in
+        let%bind () = assert_ constr_constraint in
         let%bind arg_pat =
           match arg_pat, arg_pat_type with
           | Some arg_pat, Some arg_pat_type ->
@@ -308,6 +393,17 @@ module Pattern = struct
           (let%map constr_desc = constr_desc
            and arg_pat = arg_pat in
            Tpat_construct (constr_desc, arg_pat))
+      | Ppat_constraint (pat, pat_type') ->
+        let@ pat_type' =
+          let open Binder.Let_syntax in
+          let& pat_type' = convert_core_type pat_type' in
+          of_type pat_type'
+        in
+        let%bind pat_desc = infer_pat_desc pat pat_type' in
+        return
+          (let%map () = pat_type =~ pat_type'
+           and pat_desc = pat_desc in
+           pat_desc)
     and infer_pats pats
         : (variable list * Typedtree.pattern list Constraint.t) Binder.t
       =
@@ -364,9 +460,11 @@ module Expression = struct
             (var : string)])
 
 
-  let inst_constr_decl name : (Type.t option * Type.t) Binder.t =
+  let inst_constr_decl name
+      : (Type.t option * Type.t * Constraint.Rigid.t) Binder.t
+    =
     let open Binder.Let_syntax in
-    let& vars, constr_arg, constr_type =
+    let& constr_alphas, constr_arg, constr_type, constr_constraints =
       let%bind.Computation env = env in
       (* TODO: Remove code duplication *)
       of_result (inst_constr_decl ~env name) ~message:(function
@@ -388,8 +486,15 @@ module Expression = struct
                occur! Good luck)"
                 (var : string)])
     in
-    let%bind () = exists_vars vars in
-    return (constr_arg, constr_type)
+    let%bind () = exists_vars constr_alphas in
+    let%bind constr_arg =
+      match constr_arg with
+      | Some (constr_betas, constr_arg) ->
+        let%bind () = forall_vars constr_betas in
+        return (Some constr_arg)
+      | None -> return None
+    in
+    return (constr_arg, constr_type, constr_constraints)
 
 
   let inst_label_decl label : (Type.t * Type.t) Binder.t =
@@ -424,7 +529,9 @@ module Expression = struct
     =
     let open Binder.Let_syntax in
     (* Instantiate the constructor description. *)
-    let%bind constr_arg, constr_type' = inst_constr_decl constr_name in
+    let%bind constr_arg, constr_type', constr_constraint =
+      inst_constr_decl constr_name
+    in
     (* Convert [const_arg] and [const_type'] to variables *)
     let%bind constr_arg =
       match constr_arg with
@@ -437,6 +544,7 @@ module Expression = struct
     let constr_desc =
       constr_type
       =~- constr_type'
+      >> Rigid.to_constraint constr_constraint
       >> make_constr_desc constr_name constr_arg constr_type
     in
     return (constr_desc, constr_arg)
@@ -464,13 +572,13 @@ module Expression = struct
 
 
   let infer_pat pat pat_type
-      : (binding list * Typedtree.pattern Constraint.t) Binder.t
+      : (binding list * Typedtree.pattern Constraint.t * Constraint.Rigid.t) Binder.t
     =
     let open Binder.Let_syntax in
     (* print_endline
       (Sexp.to_string_hum [%message "infer_pat" (pat : Parsetree.pattern)]); *)
     let& fragment, pat = Pattern.infer pat pat_type in
-    let existential_bindings, term_bindings = Fragment.to_bindings fragment in
+    let universal_bindings, existential_bindings, local_constraint, term_bindings = Fragment.to_bindings fragment in
     (* List.iter existential_bindings ~f:(fun (var, binding) ->
         Format.printf "Variable: %d@." (var :> int);
         Format.printf
@@ -479,8 +587,9 @@ module Expression = struct
     List.iter term_bindings ~f:(fun (term_var, var) ->
         Format.printf "Term Variable: %s@." term_var;
         Format.printf "Bound Variable: %d@." (var :> int)); *)
+    let%bind () = forall_vars universal_bindings in
     let%bind () = exists_bindings existential_bindings in
-    return (term_bindings, pat)
+    return (term_bindings, pat, local_constraint)
 
 
   let make_exp_desc_forall vars var exp_desc exp_type =
@@ -527,12 +636,12 @@ module Expression = struct
       | Pexp_fun (pat, exp) ->
         let@ var1 = exists () in
         let@ var2 = exists () in
-        let@ bindings, pat = infer_pat pat var1 in
+        let@ bindings, pat, local_constraint = infer_pat pat var1 in
         let%bind exp = infer_exp exp var2 in
         return
           (let%map () = exp_type =~= var1 @-> var2
            and pat = pat
-           and exp = def ~bindings ~in_:exp in
+           and exp = local_constraint #=> (def ~bindings ~in_:exp) in
            Texp_fun (pat, exp))
       | Pexp_app (exp1, exp2) ->
         let@ var = exists () in
@@ -597,6 +706,16 @@ module Expression = struct
               "Duplicate variable in universal quantifier (forall)"
                 (exp : Parsetree.expression)
                 (var : string)])
+      | Pexp_coerce (exp, type1, type2) ->
+        let%bind type1 = convert_core_type type1 in
+        let@ type1 = of_type type1 in
+        let%bind type2 = convert_core_type type2 in
+        let@ type2 = of_type type2 in
+        let%bind exp_desc = infer_exp_desc exp type1 in
+        return
+          (let%map () = type1 =% type2 >> (exp_type =~ type2)
+           and exp_desc = exp_desc in
+           exp_desc)
       | Pexp_field (exp, label) ->
         let@ var = exists () in
         let%bind exp = infer_exp exp var in
@@ -670,11 +789,11 @@ module Expression = struct
       let open Computation.Let_syntax in
       let%bind cases =
         List.map cases ~f:(fun { pc_lhs; pc_rhs } ->
-            let@ bindings, pat = infer_pat pc_lhs lhs_type in
+            let@ bindings, pat, local_constraint = infer_pat pc_lhs lhs_type in
             let%bind exp = infer_exp pc_rhs rhs_type in
             return
               (let%map tc_lhs = pat
-               and tc_rhs = def ~bindings ~in_:exp in
+               and tc_rhs = local_constraint #=> (def ~bindings ~in_:exp) in
                { tc_lhs; tc_rhs }))
         |> all
       in
@@ -708,10 +827,10 @@ module Expression = struct
       let open Computation.Let_syntax in
       let var = fresh () in
       let%bind fragment, pat = Pattern.infer pat var in
-      let existential_bindings, term_bindings = Fragment.to_bindings fragment in
+      let universal_bindings, existential_bindings, local_constraint, term_bindings = Fragment.to_bindings fragment in
       let%bind exp = infer_exp exp var in
       return
-        ((([], (var, None) :: existential_bindings) @. (pat &~ exp))
+        (((universal_bindings, (var, None) :: existential_bindings) @. (pat &~ (local_constraint #=> exp)))
         @=> term_bindings)
     and infer_rec_value_binding { prvb_var = term_var; prvb_expr = exp }
         : Typedtree.expression let_rec_binding Computation.t

--- a/src/typing/substitution.ml
+++ b/src/typing/substitution.ml
@@ -28,6 +28,11 @@ let of_alist alist =
 
 
 let to_alist t = Map.to_alist t
+
+let of_map t = t
+
+let to_map t = t
+
 (* 
 let of_type_vars vars =
   of_alist (List.map ~f:(fun var -> var, Constraint.fresh ()) vars) *)

--- a/src/typing/substitution.mli
+++ b/src/typing/substitution.mli
@@ -37,6 +37,14 @@ val of_alist
   :  (string * Constraint.variable) list
   -> (t, [> `Duplicate_type_variable of string ]) Result.t
 
+val of_map
+  :  (String.t, Constraint.variable, String.comparator_witness) Map.t
+  -> t
+
+val to_map
+  :  t
+  -> (String.t, Constraint.variable, String.comparator_witness) Map.t
+
 (** [to_alist t] returns the alist defined by the substitution [t]. *)
 val to_alist : t -> (string * Constraint.variable) list
 

--- a/src/typing/types.ml
+++ b/src/typing/types.ml
@@ -132,7 +132,6 @@ end
 
 type type_declaration =
   { type_name : string
-  ; type_params : string list
   ; type_kind : type_decl_kind
   }
 [@@deriving sexp_of]
@@ -152,9 +151,16 @@ and label_declaration =
 
 and constructor_declaration =
   { constructor_name : string
-  ; constructor_type_params : string list
-  ; constructor_arg : type_expr option
+  ; constructor_alphas : string list
+  ; constructor_arg : constructor_argument option
   ; constructor_type : type_expr
+  ; constructor_constraints : (type_expr * type_expr) list
+  }
+[@@deriving sexp_of]
+
+and constructor_argument =
+  { constructor_arg_betas : string list
+  ; constructor_arg_type : type_expr
   }
 [@@deriving sexp_of]
 

--- a/src/typing/types.mli
+++ b/src/typing/types.mli
@@ -85,7 +85,6 @@ end
 
 type type_declaration =
   { type_name : string
-  ; type_params : string list
   ; type_kind : type_decl_kind
   }
 [@@deriving sexp_of]
@@ -105,9 +104,16 @@ and label_declaration =
 
 and constructor_declaration =
   { constructor_name : string
-  ; constructor_type_params : string list
-  ; constructor_arg : type_expr option
+  ; constructor_alphas : string list
+  ; constructor_arg : constructor_argument option
   ; constructor_type : type_expr
+  ; constructor_constraints : (type_expr * type_expr) list
+  }
+[@@deriving sexp_of]
+
+and constructor_argument =
+  { constructor_arg_betas : string list
+  ; constructor_arg_type : type_expr
   }
 [@@deriving sexp_of]
 

--- a/test/typing/test_infer.ml
+++ b/test/typing/test_infer.ml
@@ -687,7 +687,9 @@ let%expect_test "let - identity" =
   let exp =
     (* let id x = x in id id () *)
     Pexp_let
-      ( [ { pvb_pat = Ppat_var "id"
+      ( Nonrecursive
+      , [ { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "id"
           ; pvb_expr = Pexp_fun (Ppat_var "x", Pexp_var "x")
           }
         ]
@@ -759,9 +761,11 @@ let%expect_test "let - map" =
   let env = add_list Env.empty in
   let exp =
     (* let rec map f xs = match xs with (Nil -> Nil | Cons (x, xs) -> Cons (f x, map f xs)) in let f x = x + 1 in map f Nil *)
-    Pexp_let_rec
-      ( [ { prvb_var = "map"
-          ; prvb_expr =
+    Pexp_let
+      ( Recursive
+      , [ { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "map"
+          ; pvb_expr =
               Pexp_fun
                 ( Ppat_var "f"
                 , Pexp_fun
@@ -793,7 +797,9 @@ let%expect_test "let - map" =
           }
         ]
       , Pexp_let
-          ( [ { pvb_pat = Ppat_var "f"
+          ( Nonrecursive
+          , [ { pvb_forall_vars = []
+              ; pvb_pat = Ppat_var "f"
               ; pvb_expr =
                   Pexp_fun
                     ( Ppat_var "x"
@@ -1061,10 +1067,15 @@ let%expect_test "let rec - monomorphic recursion" =
   let env = add_list Env.empty in
   let exp =
     (* let rec id x = x and id_int x = id (x : int) in id_int *)
-    Pexp_let_rec
-      ( [ { prvb_var = "id"; prvb_expr = Pexp_fun (Ppat_var "x", Pexp_var "x") }
-        ; { prvb_var = "id_int"
-          ; prvb_expr =
+    Pexp_let
+      ( Recursive
+      , [ { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "id"
+          ; pvb_expr = Pexp_fun (Ppat_var "x", Pexp_var "x")
+          }
+        ; { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "id_int"
+          ; pvb_expr =
               Pexp_fun
                 ( Ppat_var "x"
                 , Pexp_app
@@ -1137,9 +1148,11 @@ let%expect_test "let rec - monomorphic recursion" =
 let%expect_test "let rec - mutual recursion (monomorphic)" =
   let exp =
     (* let rec is_even x = if x = 0 then true else is_odd (x - 1) and is_odd x = if x = 1 then true else is_even (x - 1) in is_even *)
-    Pexp_let_rec
-      ( [ { prvb_var = "is_even"
-          ; prvb_expr =
+    Pexp_let
+      ( Recursive
+      , [ { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "is_even"
+          ; pvb_expr =
               Pexp_fun
                 ( Ppat_var "x"
                 , Pexp_ifthenelse
@@ -1153,8 +1166,9 @@ let%expect_test "let rec - mutual recursion (monomorphic)" =
                             ( Pexp_app (Pexp_prim Prim_sub, Pexp_var "x")
                             , Pexp_const (Const_int 1) ) ) ) )
           }
-        ; { prvb_var = "is_odd"
-          ; prvb_expr =
+        ; { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "is_odd"
+          ; pvb_expr =
               Pexp_fun
                 ( Ppat_var "x"
                 , Pexp_ifthenelse
@@ -1334,12 +1348,15 @@ let%expect_test "let rec - mutual recursion (monomorphic)" =
 let%expect_test "let rec - mutual recursion (polymorphic)" =
   let exp =
     (* let rec foo x = 1 and bar y = true in foo *)
-    Pexp_let_rec
-      ( [ { prvb_var = "foo"
-          ; prvb_expr = Pexp_fun (Ppat_var "x", Pexp_const (Const_int 1))
+    Pexp_let
+      ( Recursive
+      , [ { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "foo"
+          ; pvb_expr = Pexp_fun (Ppat_var "x", Pexp_const (Const_int 1))
           }
-        ; { prvb_var = "bar"
-          ; prvb_expr = Pexp_fun (Ppat_var "y", Pexp_const (Const_bool true))
+        ; { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "bar"
+          ; pvb_expr = Pexp_fun (Ppat_var "y", Pexp_const (Const_bool true))
           }
         ]
       , Pexp_var "foo" )
@@ -1397,7 +1414,9 @@ let%expect_test "f-pottier elaboration 1" =
   let exp =
     (* let u = (fun f -> ()) (fun x -> x) in u *)
     Pexp_let
-      ( [ { pvb_pat = Ppat_var "u"
+      ( Nonrecursive
+      , [ { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "u"
           ; pvb_expr =
               Pexp_app
                 ( Pexp_fun (Ppat_var "f", Pexp_const Const_unit)
@@ -1480,7 +1499,9 @@ let%expect_test "coerce" =
   let env = add_eq Env.empty in
   let exp =
     Pexp_let
-      ( [ { pvb_pat = Ppat_var "coerce"
+      ( Nonrecursive
+      , [ { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "coerce"
           ; pvb_expr =
               Pexp_forall
                 ( [ "a"; "b" ]
@@ -1493,8 +1514,7 @@ let%expect_test "coerce" =
                                 ( Pexp_var "eq"
                                 , Ptyp_constr
                                     ([ Ptyp_var "a"; Ptyp_var "b" ], "eq") )
-                            , [ { pc_lhs =
-                                    Ppat_construct ("Refl", None)
+                            , [ { pc_lhs = Ppat_construct ("Refl", None)
                                 ; pc_rhs =
                                     Pexp_coerce
                                       (Pexp_var "x", Ptyp_var "a", Ptyp_var "b")
@@ -1506,7 +1526,8 @@ let%expect_test "coerce" =
   in
   (* print_constraint_result ~env exp; *)
   print_infer_result ~env exp;
-  [%expect{|
+  [%expect
+    {|
     Variables:
     Expression:
     └──Expression:
@@ -1579,3 +1600,86 @@ let%expect_test "coerce" =
           └──Expression:
              └──Type expr: Constructor: unit
              └──Desc: Constant: () |}]
+
+let%expect_test "let rec - polymorphic recursion" =
+  let env = add_list Env.empty in
+  let exp =
+    (* let rec (type a) id : a -> a = fun x -> x and id_int x = id (x : int) in id *)
+    Pexp_let
+      ( Recursive
+      , [ { pvb_forall_vars = [ "a" ]
+          ; pvb_pat = Ppat_constraint (Ppat_var "id", Ptyp_arrow (Ptyp_var "a", Ptyp_var "a"))
+          ; pvb_expr = Pexp_fun (Ppat_var "x", Pexp_var "x")
+          }
+        ; { pvb_forall_vars = []
+          ; pvb_pat = Ppat_var "id_int"
+          ; pvb_expr =
+              Pexp_fun
+                ( Ppat_var "x"
+                , Pexp_app
+                    ( Pexp_var "id"
+                    , Pexp_constraint (Pexp_var "x", Ptyp_constr ([], "int")) )
+                )
+          }
+        ]
+      , Pexp_var "id" )
+  in
+  print_infer_result ~env exp;
+  [%expect {|
+    Variables: α377
+    Expression:
+    └──Expression:
+       └──Type expr: Arrow
+          └──Type expr: Variable: α377
+          └──Type expr: Variable: α377
+       └──Desc: Let rec
+          └──Value bindings:
+             └──Value binding:
+                └──Variable: id
+                └──Abstraction:
+                   └──Variables: α360
+                   └──Expression:
+                      └──Type expr: Arrow
+                         └──Type expr: Variable: α371
+                         └──Type expr: Variable: α371
+                      └──Desc: Function
+                         └──Pattern:
+                            └──Type expr: Variable: α371
+                            └──Desc: Variable: x
+                         └──Expression:
+                            └──Type expr: Variable: α371
+                            └──Desc: Variable
+                               └──Variable: x
+             └──Value binding:
+                └──Variable: id_int
+                └──Abstraction:
+                   └──Variables:
+                   └──Expression:
+                      └──Type expr: Arrow
+                         └──Type expr: Constructor: int
+                         └──Type expr: Constructor: int
+                      └──Desc: Function
+                         └──Pattern:
+                            └──Type expr: Constructor: int
+                            └──Desc: Variable: x
+                         └──Expression:
+                            └──Type expr: Constructor: int
+                            └──Desc: Application
+                               └──Expression:
+                                  └──Type expr: Arrow
+                                     └──Type expr: Constructor: int
+                                     └──Type expr: Constructor: int
+                                  └──Desc: Variable
+                                     └──Variable: id
+                                     └──Type expr: Constructor: int
+                               └──Expression:
+                                  └──Type expr: Constructor: int
+                                  └──Desc: Variable
+                                     └──Variable: x
+          └──Expression:
+             └──Type expr: Arrow
+                └──Type expr: Variable: α377
+                └──Type expr: Variable: α377
+             └──Desc: Variable
+                └──Variable: id
+                └──Type expr: Variable: α377 |}]


### PR DESCRIPTION
This PR explores the possibility of using stratified type inference over the current implication constraint system. 
The implication constraints are rather restrictive and this proves as a possible simple alternative without much modification to the current code-base. 