### PR TITLE
Structure (Refactor)

### DIFF
--- a/src/constraints/constraints.ml
+++ b/src/constraints/constraints.ml
@@ -18,7 +18,6 @@ module Make (Algebra : Algebra) = struct
   include Private.Constraint.Make (Algebra)
   module Solver = Private.Solver.Make (Algebra)
   module Abbrev_type = Solver.Abbrev_type
-  module Abbrev = Solver.Abbrev
   module Abbreviations = Solver.Abbreviations
 
   let solve = Solver.solve

--- a/src/constraints/constraints.mli
+++ b/src/constraints/constraints.mli
@@ -119,24 +119,15 @@ module Make (Algebra : Algebra) : sig
   module Abbrev_type : sig
     type t [@@deriving sexp_of, compare]
 
-    type structure =
-      | Var
-      | Structure of t Type_former.t
-
-    val make : structure -> t
-  end
-
-  module Abbrev : sig
-    type t
-
-    val make : Abbrev_type.t Type_former.t -> Abbrev_type.t -> t
+    val make_var : unit -> t
+    val make_former : t Type_former.t -> t
   end
 
   module Abbreviations : sig
     type t
 
     val empty : t
-    val add : t -> abbrev:Abbrev.t -> t
+    val add : t -> abbrev:Abbrev_type.t Type_former.t * Abbrev_type.t -> t
   end
 
   module Solver : sig

--- a/src/constraints/solver/generalization_intf.ml
+++ b/src/constraints/solver/generalization_intf.ml
@@ -48,30 +48,22 @@ module type S = sig
   module Abbrev_type : sig
     type t [@@deriving sexp_of, compare]
 
-    type structure =
-      | Var
-      | Structure of t former
-
-    val make : structure -> t
+    val make_var : unit -> t
+    val make_former : t former -> t
   end
 
-  module Abbrev : sig
-    type t 
+  type ctx
 
-    val make : Abbrev_type.t former -> Abbrev_type.t -> t
-  end
+  val empty_ctx : ctx
 
   module Abbreviations : sig
-    type t
+    type t = ctx
 
-    val empty : t
-    val add : t -> abbrev:Abbrev.t -> t
+    val add : t -> abbrev:Abbrev_type.t former * Abbrev_type.t -> t
   end
 
   module Equations : sig
-    type t
-
-    val empty : t
+    type t = ctx
 
     exception Inconsistent
 
@@ -79,9 +71,10 @@ module type S = sig
   end
 
   module Unifier : Unifier.S
-  open Unifier
 
-  val unify : state -> ctx:Equations.t * Abbreviations.t -> Type.t -> Type.t -> unit
+  val unify : state -> ctx:ctx -> Unifier.Type.t -> Unifier.Type.t -> unit
+
+  open Unifier
 
   (** [make_rigid_var state rigid_var] creates rigid unification variable. *)
   val make_rigid_var : state -> Rigid_var.t -> Type.t
@@ -151,7 +144,6 @@ module type S = sig
     -> rigid_vars:Rigid_var.t list
     -> types:Type.t list
     -> variables * scheme list
-
 end
 
 (** The interface of {generalization.ml}. *)

--- a/src/constraints/solver/solver.mli
+++ b/src/constraints/solver/solver.mli
@@ -23,24 +23,16 @@ module Make (Algebra : Algebra) : sig
   module Abbrev_type : sig
     type t [@@deriving sexp_of, compare]
 
-    type structure =
-      | Var
-      | Structure of t Type_former.t
-
-    val make : structure -> t
+    val make_var : unit -> t
+    val make_former : t Type_former.t -> t
   end
 
-  module Abbrev : sig
-    type t 
-
-    val make : Abbrev_type.t Type_former.t -> Abbrev_type.t -> t
-  end
 
   module Abbreviations : sig
     type t
 
     val empty : t
-    val add : t -> abbrev:Abbrev.t -> t
+    val add : t -> abbrev:(Abbrev_type.t Type_former.t * Abbrev_type.t) -> t
   end
 
   (** [solve t] solves [t] and computes it's value. *)
@@ -70,6 +62,7 @@ module Private : sig
   module Unifier (Structure : Structure.S) :
     Unifier.S
       with type 'a structure = 'a Structure.t
+       and type 'a metadata = 'a Structure.Metadata.t
        and type ctx = Structure.ctx
        and type 'a expansive = 'a Structure.expansive
 

--- a/src/constraints/solver/structure.ml
+++ b/src/constraints/solver/structure.ml
@@ -94,7 +94,6 @@ module Scoped_abbreviations
     (Structure : S)
     (Id : Identifiable with type 'a t := 'a Structure.t) =
 struct
-
   module Abbrev = struct
     module Type = struct
       type t = desc ref [@@deriving sexp_of]
@@ -149,7 +148,6 @@ struct
     end
   end
 
-
   include Structure
 
   module Metadata = struct
@@ -173,7 +171,6 @@ struct
     let update_scope t scope = if t.scope < scope then t.scope <- scope
     let super_ t = t.super_
   end
-
 
   type ctx = Abbrev.Ctx.t * Structure.ctx
 
@@ -258,389 +255,54 @@ struct
         t2)
 end
 
-(* 
-module Ambivalent (Structure : S) = struct
-  open Structure
+module Rigid_structure (Structure : S) = struct
+  include Structure
 
-  module Rigid_type = struct
-    type t =
-      | Rigid_var of Rigid_var.t
-      | Structure of t Descriptor.t
-  end
+  type 'a t =
+    | Rigid_var of Rigid_var.t
+    | Structure of 'a Structure.t
+  [@@deriving sexp_of]
 
-  module Equations = struct
-    module Scope = struct
-      type t = int [@@deriving sexp_of]
-
-      (* let min = min *)
-      let max = max
-      let outermost_scope = 0
-    end
-
-    type 'a scoped = 'a * Scope.t
-
-    module Ctx = struct
-      type t =
-        (Rigid_var.t, Rigid_type.t scoped, Rigid_var.comparator_witness) Map.t
-
-      let empty = Map.empty (module Rigid_var)
-
-      exception Inconsistent = Descriptor.Cannot_merge
-
-      let rec add_equation ~metadata ~expansive ~ctx t rigid_var type1 scope =
-        match Map.find !t rigid_var with
-        | Some (type2, _) ->
-          add_equations ~metadata ~expansive ~ctx t type1 type2 scope
-        | None -> t := Map.set !t ~key:rigid_var ~data:(type1, scope)
+  let iter t ~f =
+    match t with
+    | Rigid_var _ -> ()
+    | Structure structure -> Structure.iter structure ~f
 
 
-      and add_equations ~metadata ~expansive ~ctx t type1 type2 scope =
-        let open Rigid_type in
-        let add_equations type1 type2 =
-          add_equations ~metadata ~expansive ~ctx t type1 type2 scope
-        in
-        let add_equation rigid_var type_ =
-          add_equation ~metadata ~expansive ~ctx t rigid_var type_ scope
-        in
-        match type1, type2 with
-        | Rigid_var rigid_var, type2 -> add_equation rigid_var type2
-        | type1, Rigid_var rigid_var -> add_equation rigid_var type1
-        | Structure structure1, Structure structure2 ->
-          ignore
-            (Descriptor.merge
-               ~expansive
-               ~ctx
-               ~equate:add_equations
-               (structure1, metadata)
-               (structure2, metadata)
-              : _ Descriptor.t)
+  let map t ~f =
+    match t with
+    | Rigid_var rigid_var -> Rigid_var rigid_var
+    | Structure structure -> Structure (Structure.map structure ~f)
 
 
-      let add ~expansive ~ctx t type1 type2 scope =
-        let t = ref t in
-        let metadata : Rigid_type.t Metadata.t = Metadata.empty () in
-        add_equations ~metadata ~expansive ~ctx t type1 type2 scope;
-        !t
+  let fold t ~f ~init =
+    match t with
+    | Rigid_var _ -> init
+    | Structure structure -> Structure.fold structure ~f ~init
 
 
-      let get_equation t rigid_var = Map.find t rigid_var
-    end
-  end
+  let merge ~expansive ~ctx ~equate (desc1, metadata1) (desc2, metadata2) =
+    match desc1, desc2 with
+    | Rigid_var rigid_var1, Rigid_var rigid_var2
+      when Rigid_var.compare rigid_var1 rigid_var2 = 0 -> Rigid_var rigid_var1
+    | Structure desc1, Structure desc2 ->
+      Structure
+        (Structure.merge
+           ~expansive
+           ~ctx
+           ~equate
+           (desc1, metadata1)
+           (desc2, metadata2))
+    | _ -> raise Cannot_merge
+end
 
-  module Metadata = struct
-    type 'a t =
-      { mutable scope : Equations.Scope.t
-      ; super_ : 'a Metadata.t
-      }
-    [@@deriving sexp_of]
+module Rigid_identifiable (S : S) (Id : Identifiable with type 'a t = 'a S.t) =
+struct
+  module Rigid_structure = Rigid_structure (S)
+  include Rigid_structure
 
-    let empty () =
-      { scope = Equations.Scope.outermost_scope; super_ = Metadata.empty () }
-
-
-    let merge t1 t2 =
-      { scope = Equations.Scope.max t1.scope t2.scope
-      ; super_ = Metadata.merge t1.super_ t2.super_
-      }
-
-
-    let scope t = t.scope
-    let update_scope t scope = if t.scope < scope then t.scope <- scope
-    let super_ t = t.super_
-  end
-
-  module Descriptor = struct
-    type 'a t =
-      | Rigid_var of Rigid_var.t
-      | Structure of 'a Descriptor.t
-    [@@deriving sexp_of]
-
-    let iter t ~f =
-      match t with
-      | Rigid_var _ -> ()
-      | Structure structure -> Descriptor.iter structure ~f
-
-
-    let fold t ~f ~init =
-      match t with
-      | Rigid_var _ -> init
-      | Structure structure -> Descriptor.fold structure ~f ~init
-
-
-    let map t ~f =
-      match t with
-      | Rigid_var rigid_var -> Rigid_var rigid_var
-      | Structure structure -> Structure (Descriptor.map structure ~f)
-
-
-    type ctx = Equations.Ctx.t * Descriptor.ctx
-
-    type 'a expansive =
-      { make : 'a t -> 'a
-      ; super_ : 'a Descriptor.expansive
-      }
-
-    let ectx = fst
-    let sctx = snd
-
-    exception Cannot_expand
-
-    let convert_rigid_type ~expansive rigid_type =
-      let rec loop rigid_type =
-        let open Rigid_type in
-        expansive.make
-          (match rigid_type with
-          | Rigid_var rigid_var -> Rigid_var rigid_var
-          | Structure structure ->
-            let structure = Descriptor.map structure ~f:loop in
-            Structure structure)
-      in
-      loop rigid_type
-
-
-    (* [expand ~expansive ~ctx rigid_var] returns a ['a Structure.t, scope] determined by [ctx].
-     Otherwise, raises Cannot_expansive *)
-    let expand ~expansive ~ctx rigid_var =
-      let rec loop rigid_var scope =
-        let open Rigid_type in
-        match Equations.Ctx.get_equation (ectx ctx) rigid_var with
-        | Some (Rigid_var rigid_var, scope') ->
-          loop rigid_var (Equations.Scope.max scope scope')
-        | Some (Structure structure, scope') ->
-          (* Convert [structure] using [term]. *)
-          let structure =
-            Descriptor.map structure ~f:(convert_rigid_type ~expansive)
-          in
-          structure, Equations.Scope.max scope scope'
-        | None -> raise Cannot_expand
-      in
-      loop rigid_var Equations.Scope.outermost_scope
-
-
-    (* [is_equivalent] *)
-    let is_equivalent ~ctx rigid_var1 rigid_var2 =
-      let rec loop rigid_var1 rigid_var2 scope =
-        let open Rigid_type in
-        if rigid_var1 = rigid_var2
-        then true, scope
-        else (
-          match Equations.Ctx.get_equation (ectx ctx) rigid_var1 with
-          | Some (Rigid_var rigid_var2', scope') ->
-            if rigid_var2 = rigid_var2'
-            then true, max scope scope'
-            else loop rigid_var2' rigid_var2 (Equations.Scope.max scope scope')
-          | _ -> false, Equations.Scope.outermost_scope)
-      in
-      let first, scope1 =
-        loop rigid_var1 rigid_var2 Equations.Scope.outermost_scope
-      in
-      if first
-      then true, scope1
-      else loop rigid_var2 rigid_var1 Equations.Scope.outermost_scope
-
-
-    exception Cannot_merge = Descriptor.Cannot_merge
-
-    let merge ~expansive ~ctx ~equate (t1, metadata1) (t2, metadata2) =
-      match t1, t2 with
-      | Structure structure1, Structure structure2 ->
-        Structure
-          (Descriptor.merge
-             ~expansive:expansive.super_
-             ~ctx:(sctx ctx)
-             ~equate
-             (structure1, Metadata.super_ metadata1)
-             (structure2, Metadata.super_ metadata2))
-      | Rigid_var rigid_var, Structure structure
-      | Structure structure, Rigid_var rigid_var ->
-        (* Expand rigid variable to structure under [ectx ctx]. *)
-        let structure', scope =
-          try expand ~expansive ~ctx rigid_var with
-          | Cannot_expand -> raise Cannot_merge
-        in
-        (* Equate the 2 structures. *)
-        ignore
-          (Descriptor.merge
-             ~expansive:expansive.super_
-             ~ctx:(sctx ctx)
-             ~equate
-             (structure, Metadata.super_ metadata1)
-             (structure', Metadata.super_ metadata2)
-            : _ Descriptor.t);
-        (* Pick an arbitrary metadata to update the scope *)
-        Metadata.update_scope metadata1 scope;
-        (* Descriptor remains as [Rigid_var] *)
-        Rigid_var rigid_var
-      | Rigid_var rigid_var1, Rigid_var rigid_var2 ->
-        (* Determine whether [rigid_var1], [rigid_var2] are equivalent under
-         [ectx ctx]. *)
-        let is_equiv, scope = is_equivalent ~ctx rigid_var1 rigid_var2 in
-        if not is_equiv then raise Cannot_merge;
-        (* Pick an arbitrary metadata to update the scope *)
-        Metadata.update_scope metadata1 scope;
-        (* Return arbitrary rigid variable *)
-        Rigid_var rigid_var1
-  end
-
-  (* let merge_scoped scoped1 scoped2 ~f =
-    let t1, scope1 = scoped1 in
-    let t2, scope2 = scoped2 in
-    f t1 t2, Equations.Scope.min scope1 scope2
-
-
-  let decompose_scope (_, scope1) (_, scope2) =
-    Equations.Scope.max scope1 scope2
-
-
-  let merge_structure t1 t2 =
-    match t1.structure, t2.structure with
-    | None, structure | structure, None -> structure
-    | Some structure1, Some structure2 ->
-      (* We select an arbitrary structure, namely the first.*)
-      Some
-        (merge_scoped structure1 structure2 ~f:(fun structure _ -> structure))
-
-
-  let merge_rigid_vars t1 t2 =
-    Hashtbl.merge t1.rigid_vars t2.rigid_vars ~f:(fun ~key:_ -> function
-      | `Left desc | `Right desc -> Some desc
-      | `Both (desc1, desc2) ->
-        Some
-          (merge_scoped desc1 desc2 ~f:(fun is_expansive1 is_expansive2 ->
-               is_expansive1 && is_expansive2)))
-
-
-  let find_decomposable_rigid_var_scope t1 t2 =
-    Hash_set.inter (rigid_vars t1) (rigid_vars t2)
-    |> Hash_set.fold ~init:None ~f:(fun acc rigid_var ->
-           let find_scope t = Hashtbl.find_exn t.rigid_vars rigid_var |> snd in
-           let scope' = Equations.Scope.min (find_scope t1) (find_scope t2) in
-           match acc with
-           | None -> Some scope'
-           | Some scope -> if scope' < scope then Some scope' else Some scope)
-
-
-  let get_min_expansive ~(ctx : ctx) t =
-    (* TODO: Come up w/ clever datastructure to compute this efficiently *)
-    Hashtbl.fold
-      t.rigid_vars
-      ~init:None
-      ~f:(fun ~key:rigid_var ~data:(is_expansive, rigid_var_scope) acc ->
-        if not is_expansive
-        then acc
-        else (
-          match acc, Equations.Ctx.get_equation (ectx ctx) rigid_var with
-          | None, Some rigid_type ->
-            Some ((rigid_var, rigid_var_scope), rigid_type)
-          | Some (_, rigid_type), Some rigid_type'
-            when snd rigid_type' < snd rigid_type ->
-            Some ((rigid_var, rigid_var_scope), rigid_type')
-          | _ -> acc))
-
-
-  exception Cannot_decompose
-
-  let decompose ~expansive ~ctx ~equate t1 t2 =
-    (* In order to decompose 2 ambivalent types, we determine the common member 
-       (if one exists) with the smallest "scope" to decompose "on". *)
-    (* There are 2 rules for decomposition of ambivalent types:
-       - decomposing on the structure
-       - decomposing via a common rigid variable *)
-    match find_decomposable_rigid_var_scope t1 t2 with
-    | Some scope ->
-      (* We can decompose on the common rigid var [rigid_var] between [t1] 
-         and [t2]. *)
-      (* From [find_decomposable_rigid_var], we know that [scope] the minimum
-         scope for a common rigid variable. *)
-      let scope =
-        Equations.Scope.max t1.scope t2.scope |> Equations.Scope.max scope
-      in
-      let structure = merge_structure t1 t2 in
-      let rigid_vars = merge_rigid_vars t1 t2 in
-      { structure; rigid_vars; scope }
-    | None ->
-      (* If there is no-common rigid variable, then we attempt to decompose on the 
-         structure *)
-      (match Option.both t1.structure t2.structure with
-      | None -> raise Cannot_decompose
-      | Some (structure1, structure2) ->
-        (* Determine the merged structure *)
-        let structure =
-          merge_scoped
-            structure1
-            structure2
-            ~f:
-              (Structure.merge
-                 ~expansive:expansive.sexpansive
-                 ~ctx:(sctx ctx)
-                 ~equate)
-        in
-        (* Compute the required scope for the decomposition. *)
-        let scope =
-          Equations.Scope.max t1.scope t2.scope
-          |> Equations.Scope.max (decompose_scope structure1 structure2)
-        in
-        (* Merge the rigid variables *)
-        let rigid_vars = merge_rigid_vars t1 t2 in
-        { structure = Some structure; scope; rigid_vars })
-
-
-  exception Cannot_expand
-
-
-
-
-  let expand ~expansive ~(ctx : ctx) t1 t2 =
-    (* We first must determine which ambivalence we will
-       be expanding. *)
-    let t, (rigid_var, rigid_type) =
-      match get_min_expansive ~ctx t1, get_min_expansive ~ctx t2 with
-      | None, None -> raise Cannot_expand
-      | Some expansive, None -> t1, expansive
-      | None, Some expansive -> t2, expansive
-      | ( Some ((_, rigid_type1) as expansive1)
-        , Some ((_, rigid_type2) as expansive2) ) ->
-        if snd rigid_type1 < snd rigid_type2
-        then t1, expansive1
-        else t2, expansive2
-    in
-    (* We now add [rigid_type] to [t]. *)
-    (match fst rigid_type with
-    | Rigid_type.Rigid_var rigid_var' ->
-      (* Add [rigid_var'] to [rigid_vars] w/ the scope of the equation. *)
-      (match
-         Hashtbl.add t.rigid_vars ~key:rigid_var' ~data:(true, snd rigid_type)
-       with
-      | `Ok | `Duplicate -> ())
-    | Rigid_type.Structure structure ->
-      (match t.structure with
-      | Some _ -> ()
-      | None ->
-        (* Convert [structure] using [term]. *)
-        let structure =
-          Structure.map structure ~f:(convert_rigid_type ~make:expansive.make)
-        in
-        t.structure <- Some (structure, snd rigid_type)));
-    (* Set [rigid_var]  to be non-expansive *)
-    Hashtbl.set t.rigid_vars ~key:(fst rigid_var) ~data:(false, snd rigid_var)
-
-
-  let is_variable t =
-    Option.is_none t.structure && Hashtbl.is_empty t.rigid_vars *)
-
-  (* let merge ~expansive ~(ctx : ctx) ~equate t1 t2 =
-    if is_variable t1
-    then t2
-    else if is_variable t2
-    then t1
-    else (
-      let rec loop () =
-        try decompose ~expansive ~ctx ~equate t1 t2 with
-        | Structure.Cannot_merge -> raise Cannot_merge
-        | Cannot_decompose ->
-          (try expand ~expansive ~ctx t1 t2 with
-          | Cannot_expand -> raise Cannot_merge);
-          loop ()
-      in
-      loop ()) *) *)
-(* end *)
+  let id t =
+    match t with
+    | Rigid_var var -> 2 * Rigid_var.hash var
+    | Structure structure -> (2 * Id.id structure) + 1
+end

--- a/src/constraints/solver/structure_intf.ml
+++ b/src/constraints/solver/structure_intf.ml
@@ -17,16 +17,23 @@ open! Import
 
 module type S = sig
   (** A structure defines the "structure" of the unification type.
-      Namely, the unification type is given by the fixed point of the 
-      functor ['a structure].
-      
-      Some examples of structures include:
-      - First order terms
-      - Rigid first terms
-      - Rows
-      - Ambivalence
+
+      We define a structure as a pair [(desc, metadata)], consistings of a descriptor
+      ['a desc] and some metadata ['a metadata]. We explicitly split these for composability 
+      reasons. 
   *)
-  type 'a t [@@deriving sexp_of]
+  
+  (** ['a desc] represents the "descriptor" (or the syntactic structure) of the structure *)
+  type 'a desc
+
+  (** ['a metadata] represents the metadata of the structure. *)
+  type 'a metadata
+
+  type 'a t =
+    { desc : 'a desc
+    ; metadata : 'a metadata
+    }
+  [@@deriving sexp_of]
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
   val iter : 'a t -> f:('a -> unit) -> unit
@@ -124,7 +131,6 @@ module type Intf = sig
     type 'a t
 
     val make : 'a S.t -> 'a t
-
     val repr : 'a t -> 'a S.t
 
     type 'a expansive =

--- a/src/constraints/solver/structure_intf.ml
+++ b/src/constraints/solver/structure_intf.ml
@@ -190,13 +190,15 @@ module type Intf = sig
     end
   end
 
-  (* module Abbreviations (S : S) (Id : Identifiable with type 'a t := 'a S.t) : sig
+  module Abbreviations
+      (S : S)
+      (Id : Identifiable with type 'a t := 'a S.Descriptor.t) : sig
     module Abbrev_type : sig
       type t [@@deriving sexp_of, compare]
 
       type structure =
         | Var
-        | Structure of t S.t
+        | Structure of t S.Descriptor.t
 
       val make : structure -> t
     end
@@ -204,7 +206,7 @@ module type Intf = sig
     module Abbrev : sig
       type t
 
-      val make : Abbrev_type.t S.t -> Abbrev_type.t -> t
+      val make : Abbrev_type.t S.Descriptor.t -> Abbrev_type.t -> t
     end
 
     module Ctx : sig
@@ -214,21 +216,26 @@ module type Intf = sig
       val add : t -> abbrev:Abbrev.t -> t
     end
 
-    type 'a t
+    module Metadata : Metadata with type 'a t = 'a S.Metadata.t
 
-    val make : 'a S.t -> 'a t
-    val repr : 'a t -> 'a S.t
+    module Descriptor : sig
+      type 'a t
 
-    type 'a expansive =
-      { make_structure : 'a S.t -> 'a
-      ; make_var : unit -> 'a
-      ; sexpansive : 'a S.expansive
-      }
+      val make : 'a S.Descriptor.t -> 'a t
+      val repr : 'a t -> 'a S.Descriptor.t
 
-    include
-      S
-        with type 'a t := 'a t
-         and type ctx = Ctx.t * S.ctx
-         and type 'a expansive := 'a expansive
-  end *)
+      type 'a expansive =
+        { make_structure : 'a S.Descriptor.t -> 'a
+        ; make_var : unit -> 'a
+        ; super_: 'a S.Descriptor.expansive
+        }
+
+      include
+        Descriptor
+          with type 'a t := 'a t
+           and type 'a metadata := 'a Metadata.t
+           and type ctx = Ctx.t * S.Descriptor.ctx
+           and type 'a expansive := 'a expansive
+    end
+  end
 end

--- a/src/constraints/solver/structure_intf.ml
+++ b/src/constraints/solver/structure_intf.ml
@@ -15,39 +15,36 @@
 
 open! Import
 
-module type S = sig
-  (** A structure defines the "structure" of the unification type.
+module type Identifiable = sig
+  type 'a t
 
-      We define a structure as a pair [(desc, metadata)], consistings of a descriptor
-      ['a desc] and some metadata ['a metadata]. We explicitly split these for composability 
-      reasons. 
-  *)
-  
-  (** ['a desc] represents the "descriptor" (or the syntactic structure) of the structure *)
-  type 'a desc
+  val id : 'a t -> int
+end
 
-  (** ['a metadata] represents the metadata of the structure. *)
+module type Metadata = sig
+  type 'a t [@@deriving sexp_of]
+
+  val empty : unit -> 'a t
+  val merge : 'a t -> 'a t -> 'a t
+end
+
+module type Descriptor = sig
+  type 'a t [@@deriving sexp_of]
   type 'a metadata
-
-  type 'a t =
-    { desc : 'a desc
-    ; metadata : 'a metadata
-    }
-  [@@deriving sexp_of]
 
   val map : 'a t -> f:('a -> 'b) -> 'b t
   val iter : 'a t -> f:('a -> unit) -> unit
   val fold : 'a t -> f:('a -> 'b -> 'b) -> init:'b -> 'b
 
-  (** Structures must exhibit [merge], which is the ability
-      to compute a logically consistent structure from 2 structures. 
+  (** Descriptors must exhibit [merge], which is the ability
+      to compute a logically consistent descriptor from 2 descriptor. 
 
-      If the 2 structures are not consistent, then we raise [Cannot_merge].
+      If the 2 descriptors are not consistent, then we raise [Cannot_merge].
       
       Consistency is determined via the ability to emit first-order equalities,
       provided by [equate].
 
-      In some cases, logical consistency of 2 structures requires a context. 
+      In some cases, logical consistency of 2 descriptor requires a context. 
       (e.g. Abbreviations, and Ambivalence), thus [merge] requires a
       context [ctx]. 
       
@@ -64,15 +61,22 @@ module type S = sig
     :  expansive:'a expansive
     -> ctx:ctx
     -> equate:('a -> 'a -> unit)
-    -> 'a t
-    -> 'a t
+    -> 'a t * 'a metadata
+    -> 'a t * 'a metadata
     -> 'a t
 end
 
-module type Identifiable = sig
-  type 'a t
+module type S = sig
+  (** A structure defines the "structure" of the unification type.
 
-  val id : 'a t -> int
+      We define a structure as a pair [(desc, metadata)], consistings of a descriptor
+      ['a desc] and some metadata ['a metadata]. 
+      
+      We explicitly split these for composability reasons. 
+  *)
+  module Metadata : Metadata
+
+  module Descriptor : Descriptor with type 'a metadata := 'a Metadata.t
 end
 
 module type Intf = sig
@@ -86,25 +90,107 @@ module type Intf = sig
   end
 
   module Of_former (Former : Type_former.S) : sig
-    type 'a t = 'a Former.t
+    module Metadata : Metadata with type 'a t = unit
 
-    include
-      S with type 'a t := 'a t and type ctx = unit and type 'a expansive = unit
+    module Descriptor :
+      Descriptor
+        with type 'a t = 'a Former.t
+         and type 'a metadata := 'a Metadata.t
+         and type 'a expansive = unit
+         and type ctx = unit
   end
 
   module First_order (S : S) : sig
-    type 'a t =
-      | Var
-      | Structure of 'a S.t
+    module Metadata : Metadata with type 'a t = 'a S.Metadata.t
 
-    include
-      S
-        with type 'a t := 'a t
-         and type ctx = S.ctx
-         and type 'a expansive = 'a S.expansive
+    module Descriptor : sig
+      type 'a t =
+        | Var
+        | Structure of 'a S.Descriptor.t
+      [@@deriving sexp_of]
+
+      include
+        Descriptor
+          with type 'a t := 'a t
+           and type 'a metadata := 'a Metadata.t
+           and type ctx = S.Descriptor.ctx
+           and type 'a expansive = 'a S.Descriptor.expansive
+    end
   end
 
-  module Abbreviations (S : S) (Id : Identifiable with type 'a t := 'a S.t) : sig
+  module Ambivalent (S : S) : sig
+    module Rigid_type : sig
+      type t =
+        | Rigid_var of Rigid_var.t
+        | Structure of t S.Descriptor.t
+    end
+
+    module Equations : sig
+      module Scope : sig
+        (** [t] represents the "scope" of the equation. It is used to track 
+            consistency in level-based generalization *)
+        type t = int
+
+        val outermost_scope : t
+      end
+
+      module Ctx : sig
+        (** [t] represents the equational scope used for Ambivalence *)
+        type t
+
+        (** [empty] is the empty equational context. *)
+        val empty : t
+
+        exception Inconsistent
+
+        (** [add t type1 type2 scope] adds the equation [type1 = type2] 
+            in the scope [scope]. *)
+        val add
+          :  expansive:Rigid_type.t S.Descriptor.expansive
+          -> ctx:S.Descriptor.ctx
+          -> t
+          -> Rigid_type.t
+          -> Rigid_type.t
+          -> Scope.t
+          -> t
+      end
+    end
+
+    module Metadata : sig
+      type 'a t [@@deriving sexp_of]
+
+      (** [scope t] *)
+      val scope : 'a t -> Equations.Scope.t
+
+      (** [update_scope t scope] updates the scope of [t] according to [scope]. *)
+      val update_scope : 'a t -> Equations.Scope.t -> unit
+
+      (** [super_ t] returns the parent metadata. *)
+      val super_ : 'a t -> 'a S.Metadata.t
+
+      include Metadata with type 'a t := 'a t
+    end
+
+    module Descriptor : sig
+      type 'a t =
+        | Rigid_var of Rigid_var.t
+        | Structure of 'a S.Descriptor.t
+
+      type 'a expansive =
+        { make : 'a t -> 'a
+        ; super_ : 'a S.Descriptor.expansive
+        }
+
+      include
+        Descriptor
+          with type 'a t := 'a t
+           and type 'a metadata := 'a Metadata.t
+           and type ctx = Equations.Ctx.t * S.Descriptor.ctx
+           and type 'a expansive := 'a expansive
+    end
+  end
+
+  (* module Abbreviations (S : S) (Id : Identifiable with type 'a t := 'a S.t) : sig
     module Abbrev_type : sig
       type t [@@deriving sexp_of, compare]
 
@@ -144,77 +230,5 @@ module type Intf = sig
         with type 'a t := 'a t
          and type ctx = Ctx.t * S.ctx
          and type 'a expansive := 'a expansive
-  end
-
-  module Ambivalent (S : S) : sig
-    module Rigid_type : sig
-      type t =
-        | Rigid_var of Rigid_var.t
-        | Structure of t S.t
-    end
-
-    module Equations : sig
-      module Scope : sig
-        (** [t] represents the "scope" of the equation. It is used to track 
-            consistency in level-based generalization *)
-        type t = int
-
-        val outermost_scope : t
-      end
-
-      module Ctx : sig
-        (** [t] represents the equational scope used for Ambivalence *)
-        type t
-
-        (** [empty] is the empty equational context. *)
-        val empty : t
-
-        exception Inconsistent
-
-        (** [add t type1 type2 scope] adds the equation [type1 = type2] 
-            in the scope [scope]. *)
-        val add
-          :  expansive:Rigid_type.t S.expansive
-          -> ctx:S.ctx
-          -> t
-          -> Rigid_type.t
-          -> Rigid_type.t
-          -> Scope.t
-          -> t
-      end
-    end
-
-    (** ['a t] represents an ambivalent structure w/ children of type ['a]. *)
-    type 'a t
-
-    type 'a desc =
-      | Flexible_var
-      | Rigid_var of Rigid_var.t
-      | Structure of 'a S.t
-
-    (** [make desc] returns a new ambivalent type w/ descriptor [desc]. *)
-    val make : 'a desc -> 'a t
-
-    (** [desc t] returns the descriptor of the ambivalent type [t]. *)
-    val desc : 'a t -> 'a desc
-
-    val set_desc : 'a t -> 'a desc -> unit
-
-    (** [scope t] returns the scope of the ambivalent structure. *)
-    val scope : 'a t -> Equations.Scope.t
-
-    (** [update_scope t scope] updates the scope of [t] according to [scope]. *)
-    val update_scope : 'a t -> Equations.Scope.t -> unit
-
-    type 'a expansive =
-      { make : 'a t -> 'a
-      ; sexpansive : 'a S.expansive
-      }
-
-    include
-      S
-        with type 'a t := 'a t
-         and type ctx = Equations.Ctx.t * S.ctx
-         and type 'a expansive := 'a expansive
-  end
+  end *)
 end

--- a/src/constraints/solver/unifier.ml
+++ b/src/constraints/solver/unifier.ml
@@ -83,6 +83,12 @@ module Make (Structure : Structure.S) = struct
       Union_find.set t { desc with structure }
 
 
+    let get_metadata t = (desc t).metadata
+
+    let set_metadata t metadata = 
+      let desc = desc t in
+      Union_find.set t { desc with metadata }
+
     (* [compare t1 t2] computes the ordering of [t1, t2],
      based on their unique identifiers. *)
 

--- a/src/constraints/solver/unifier.ml
+++ b/src/constraints/solver/unifier.ml
@@ -30,10 +30,9 @@ module Make (Structure : Structure.S) = struct
   *)
 
   type 'a metadata = 'a Structure.Metadata.t [@@deriving sexp_of]
-  type 'a structure = 'a Structure.Descriptor.t [@@deriving sexp_of]
-
-  type ctx = Structure.Descriptor.ctx
-  type 'a expansive = 'a Structure.Descriptor.expansive
+  type 'a structure = 'a Structure.t [@@deriving sexp_of]
+  type ctx = Structure.ctx
+  type 'a expansive = 'a Structure.expansive
 
   module Type = struct
     (* A graphical type consists of a [Union_find] node,
@@ -85,9 +84,10 @@ module Make (Structure : Structure.S) = struct
 
     let get_metadata t = (desc t).metadata
 
-    let set_metadata t metadata = 
+    let set_metadata t metadata =
       let desc = desc t in
       Union_find.set t { desc with metadata }
+
 
     (* [compare t1 t2] computes the ordering of [t1, t2],
      based on their unique identifiers. *)
@@ -103,7 +103,8 @@ module Make (Structure : Structure.S) = struct
        metadata [metadata]. *)
     let make =
       let id = ref 0 in
-      fun structure metadata -> Union_find.make { id = post_incr id; metadata; structure }
+      fun structure metadata ->
+        Union_find.make { id = post_incr id; metadata; structure }
 
 
     module To_dot = struct
@@ -118,7 +119,8 @@ module Make (Structure : Structure.S) = struct
 
 
       let structure_to_string structure : string =
-        Structure.Descriptor.sexp_of_t (fun _ -> Atom "") structure |> Sexp.to_string_hum
+        Structure.sexp_of_t (fun _ -> Atom "") structure
+        |> Sexp.to_string_hum
 
 
       let register state t : string =
@@ -146,7 +148,7 @@ module Make (Structure : Structure.S) = struct
             let me = register state t in
             Hashtbl.set table ~key:(id t) ~data:me;
             get_structure t
-            |> Structure.Descriptor.iter ~f:(fun t ->
+            |> Structure.iter ~f:(fun t ->
                    let from = loop t in
                    arrow state ~from ~to_:me);
             me
@@ -161,6 +163,7 @@ module Make (Structure : Structure.S) = struct
       let contents = Buffer.contents state.buffer in
       [%string "digraph {\n %{contents}}"]
   end
+
   open Type
 
   (* [unify_exn] unifies two graphical types. No exception handling is 
@@ -179,17 +182,21 @@ module Make (Structure : Structure.S) = struct
   (* [unify_desc desc1 desc2] unifies the descriptors of the graph types
      (of multi-equations). *)
   and unify_desc ~expansive ~ctx desc1 desc2 =
-    let structure = unify_structure ~expansive ~ctx (desc1.structure, desc1.metadata) (desc2.structure, desc2.metadata) in
-    { id = desc1.id
-    ; structure 
-    ; metadata = Structure.Metadata.merge desc1.metadata desc2.metadata
-    }
+    let structure =
+      unify_structure
+        ~expansive
+        ~ctx
+        (desc1.structure, desc1.metadata)
+        (desc2.structure, desc2.metadata)
+    in
+    let metadata = Structure.Metadata.merge desc1.metadata desc2.metadata in
+    { id = desc1.id; structure; metadata }
 
 
   (* [unify_structure structure1 structure2] unifies two graph type node
      structures. We handle rigid variables here. *)
   and unify_structure ~expansive =
-    let merge = Structure.Descriptor.merge ~expansive in
+    let merge = Structure.merge ~expansive in
     fun ~ctx structure1 structure2 ->
       merge ~ctx ~equate:(unify_exn ~expansive ~ctx) structure1 structure2
 
@@ -198,7 +205,7 @@ module Make (Structure : Structure.S) = struct
 
   let unify ~expansive ~ctx t1 t2 =
     try unify_exn ~expansive ~ctx t1 t2 with
-    | Structure.Descriptor.Cannot_merge -> raise (Unify (t1, t2))
+    | Structure.Cannot_merge -> raise (Unify (t1, t2))
 
 
   exception Cycle of Type.t
@@ -226,7 +233,7 @@ module Make (Structure : Structure.S) = struct
       | Not_found_s _ ->
         Hashtbl.set table ~key:type_ ~data:false;
         (* Visit children *)
-        Structure.Descriptor.iter ~f:loop (get_structure type_);
+        Structure.iter ~f:loop (get_structure type_);
         (* Mark this variable as black. *)
         Hashtbl.set table ~key:type_ ~data:true
     in
@@ -236,7 +243,9 @@ module Make (Structure : Structure.S) = struct
   (* [fold_acyclic type_ ~var ~form] will perform a bottom-up fold
      over the (assumed) acyclic graph defined by the type [type_]. *)
 
-  let fold_acyclic (type a) type_ ~(f : Type.t -> a Structure.Descriptor.t -> a) : a =
+  let fold_acyclic (type a) type_ ~(f : Type.t -> a Structure.t -> a)
+      : a
+    =
     (* Hash table records whether node has been visited, and 
       it's computed value. *)
     let visited : (Type.t, a) Hashtbl.t = Hashtbl.create (module Type) in
@@ -244,7 +253,9 @@ module Make (Structure : Structure.S) = struct
     let rec loop type_ =
       try Hashtbl.find_exn visited type_ with
       | Not_found_s _ ->
-        let result = f type_ (get_structure type_ |> Structure.Descriptor.map ~f:loop) in
+        let result =
+          f type_ (get_structure type_ |> Structure.map ~f:loop)
+        in
         (* We assume we can set [type_] in [visited] *after* traversing
           it's children, since the graph is acyclic. *)
         Hashtbl.set visited ~key:type_ ~data:result;
@@ -256,7 +267,7 @@ module Make (Structure : Structure.S) = struct
   let fold_cyclic
       (type a)
       type_
-      ~(f : Type.t -> a Structure.Descriptor.t -> a)
+      ~(f : Type.t -> a Structure.t -> a)
       ~(var : Type.t -> a)
       ~(mu : Type.t -> a -> a)
       : a
@@ -275,7 +286,9 @@ module Make (Structure : Structure.S) = struct
         (* Mark this node as grey. *)
         Hashtbl.set table ~key:type_ ~data:false;
         (* Visit children *)
-        let result = f type_ (get_structure type_ |> Structure.Descriptor.map ~f:loop) in
+        let result =
+          f type_ (get_structure type_ |> Structure.map ~f:loop)
+        in
         let status = Hashtbl.find_exn table type_ in
         Hashtbl.remove table type_;
         if status then mu type_ result else result)

--- a/src/constraints/solver/unifier_intf.ml
+++ b/src/constraints/solver/unifier_intf.ml
@@ -26,6 +26,8 @@ open! Import
 module type S = sig
   (** Abstract types to be substituted by functor arguments. *)
 
+  type 'a metadata
+
   (** The type ['a structure] is the unification structures (with children of type ['a]), 
       given by the functor argument [Structure]. *)
   type 'a structure
@@ -60,7 +62,7 @@ module type S = sig
     val hash : t -> int
 
     (** [make structure] creates a new unification type w/ structure [structure]. *)
-    val make : t structure -> t
+    val make : t structure -> t metadata -> t
   end
 
   (** [unify ~ctx t1 t2] equates the graphical type nodes [t1] and [t2], 
@@ -98,7 +100,7 @@ module type S = sig
     -> f:(Type.t -> 'a structure -> 'a)
     -> var:(Type.t -> 'a)
     -> mu:(Type.t -> 'a -> 'a)
-    -> 'a 
+    -> 'a
 end
 
 (** The interface of {unifier.ml}. *)
@@ -109,7 +111,8 @@ module type Intf = sig
   (** The functor [Make]. *)
   module Make (Structure : Structure.S) :
     S
-      with type 'a structure = 'a Structure.t
-       and type ctx = Structure.ctx
-       and type 'a expansive = 'a Structure.expansive
+      with type 'a structure = 'a Structure.Descriptor.t
+       and type 'a metadata = 'a Structure.Metadata.t
+       and type ctx = Structure.Descriptor.ctx
+       and type 'a expansive = 'a Structure.Descriptor.expansive
 end

--- a/src/constraints/solver/unifier_intf.ml
+++ b/src/constraints/solver/unifier_intf.ml
@@ -57,6 +57,10 @@ module type S = sig
     (** [set_structure t structure] sets the structure of [t] to [structure]. *)
     val set_structure : t -> t structure -> unit
 
+    val get_metadata : t -> t metadata
+
+    val set_metadata : t -> t metadata -> unit
+
     (** [hash t] computes the hash of the graphical type [t]. 
      Based on it's integer field: id. *)
     val hash : t -> int

--- a/src/constraints/solver/unifier_intf.ml
+++ b/src/constraints/solver/unifier_intf.ml
@@ -115,8 +115,8 @@ module type Intf = sig
   (** The functor [Make]. *)
   module Make (Structure : Structure.S) :
     S
-      with type 'a structure = 'a Structure.Descriptor.t
+      with type 'a structure = 'a Structure.t
        and type 'a metadata = 'a Structure.Metadata.t
-       and type ctx = Structure.Descriptor.ctx
-       and type 'a expansive = 'a Structure.Descriptor.expansive
+       and type ctx = Structure.ctx
+       and type 'a expansive = 'a Structure.expansive
 end

--- a/test/constraints/alcotest/test_unifier.ml
+++ b/test/constraints/alcotest/test_unifier.ml
@@ -100,12 +100,12 @@ module Type = struct
       match t with
       | Ttyp_var x ->
         Hashtbl.find_or_add table x ~default:(fun () ->
-            Unifier.Type.make Var)
-      | Ttyp_int -> Unifier.Type.make (Structure Int)
+            Unifier.Type.make Var ())
+      | Ttyp_int -> Unifier.Type.make (Structure Int) ()
       | Ttyp_arrow (t1, t2) ->
         let t1 = loop t1 in
         let t2 = loop t2 in
-        Unifier.Type.make (Structure (Arrow (t1, t2)))
+        Unifier.Type.make (Structure (Arrow (t1, t2))) () 
     in
     loop t
 end

--- a/test/constraints/expect/test_unifier.ml
+++ b/test/constraints/expect/test_unifier.ml
@@ -48,7 +48,7 @@ module Unifier =
 module Type = Unifier.Type
 
 let unify = Unifier.unify ~expansive:() ~ctx:()
-let make_flexible_var () = Unifier.Type.make Var
+let make_flexible_var () = Unifier.Type.make Var ()
 
 let make_rigid_var =
   let next_rigid = ref (-1) in
@@ -59,10 +59,10 @@ let make_rigid_var =
           , "rigid"
             ^
             (Int.incr next_rigid;
-             Int.to_string !next_rigid) )))
+             Int.to_string !next_rigid) ))) ()
 
 
-let ( @ ) f ts = Unifier.Type.make (Structure (Constr (ts, f)))
+let ( @ ) f ts = Unifier.Type.make (Structure (Constr (ts, f))) ()
 
 let print_type t =
   let content = Type.to_dot t in

--- a/test/typing/test_infer.ml
+++ b/test/typing/test_infer.ml
@@ -71,8 +71,7 @@ let add_list env =
 let%expect_test "constant: int" =
   let exp = Pexp_const (Const_int 1) in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -82,8 +81,7 @@ let%expect_test "constant: int" =
 let%expect_test "constant: bool" =
   let exp = Pexp_const (Const_bool true) in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -93,8 +91,7 @@ let%expect_test "constant: bool" =
 let%expect_test "constant: unit" =
   let exp = Pexp_const Const_unit in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -123,8 +120,7 @@ let%expect_test "primitives" =
     Pexp_app (Pexp_app (Pexp_prim Prim_eq, lhs), Pexp_const (Const_int 12))
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -227,8 +223,7 @@ let%expect_test "function - identity" =
     Pexp_fun (Ppat_var "x", Pexp_var "x")
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α60
     Expression:
     └──Expression:
@@ -258,8 +253,7 @@ let%expect_test "function - curry" =
       )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α70,α74,α75
     Expression:
     └──Expression:
@@ -335,8 +329,7 @@ let%expect_test "function - uncurry" =
           , Pexp_app (Pexp_app (Pexp_var "f", Pexp_var "x"), Pexp_var "y") ) )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α82,α89,α87
     Expression:
     └──Expression:
@@ -415,8 +408,7 @@ let%expect_test "function - compose" =
               ) ) )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α101,α103,α99
     Expression:
     └──Expression:
@@ -488,8 +480,7 @@ let%expect_test "function - fst" =
     Pexp_fun (Ppat_tuple [ Ppat_var "x"; Ppat_var "y" ], Pexp_var "x")
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α107,α109
     Expression:
     └──Expression:
@@ -521,8 +512,7 @@ let%expect_test "function - snd" =
     Pexp_fun (Ppat_tuple [ Ppat_var "x"; Ppat_var "y" ], Pexp_var "y")
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α117,α114
     Expression:
     └──Expression:
@@ -557,8 +547,7 @@ let%expect_test "function - hd" =
       , Pexp_var "x" )
   in
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α121
     Expression:
     └──Expression:
@@ -607,8 +596,7 @@ let%expect_test "annotation - identity" =
       , Pexp_fun (Ppat_constraint (Ppat_var "x", Ptyp_var "a"), Pexp_var "x") )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α133
     Expression:
     └──Expression:
@@ -632,8 +620,7 @@ let%expect_test "annotation - identity" =
       , Pexp_fun (Ppat_constraint (Ppat_var "x", Ptyp_var "a"), Pexp_var "x") )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α144
     Expression:
     └──Expression:
@@ -661,8 +648,7 @@ let%expect_test "annotation - succ" =
               , Pexp_const (Const_int 1) ) ) )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -708,8 +694,7 @@ let%expect_test "annotation - succ" =
               , Pexp_const (Const_int 1) ) ) )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     ("Cannot unify types" (type_expr1 (Ttyp_constr (() int)))
      (type_expr2 (Ttyp_var "\206\1771"))) |}]
 
@@ -727,8 +712,7 @@ let%expect_test "let - identity" =
       )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -847,8 +831,7 @@ let%expect_test "let - map" =
               , Pexp_construct ("Nil", None) ) ) )
   in
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -1121,8 +1104,7 @@ let%expect_test "let rec - monomorphic recursion" =
       , Pexp_var "id" )
   in
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -1220,8 +1202,7 @@ let%expect_test "let rec - mutual recursion (monomorphic)" =
       , Pexp_var "is_even" )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -1396,8 +1377,7 @@ let%expect_test "let rec - mutual recursion (polymorphic)" =
       , Pexp_var "foo" )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α342
     Expression:
     └──Expression:
@@ -1460,8 +1440,7 @@ let%expect_test "f-pottier elaboration 1" =
       , Pexp_var "u" )
   in
   print_infer_result ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α354
     Expression:
     └──Expression:
@@ -1535,8 +1514,7 @@ let%expect_test "let rec - polymorphic recursion" =
       , Pexp_var "id" )
   in
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables: α384
     Expression:
     └──Expression:
@@ -1555,7 +1533,7 @@ let%expect_test "let rec - polymorphic recursion" =
                          └──Type expr: Variable: α375
                       └──Desc: Function
                          └──Pattern:
-                            └──Type expr: Variable: α375
+                            └──Type expr: Variable: α3
                             └──Desc: Variable: x
                          └──Expression:
                             └──Type expr: Variable: α375
@@ -1639,8 +1617,7 @@ let%expect_test "ambiv-f" =
   in
   (* print_constraint_result ~env exp; *)
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -1726,8 +1703,7 @@ let%expect_test "ambiv-f1" =
   in
   (* print_constraint_result ~env exp; *)
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -1818,8 +1794,7 @@ let%expect_test "ambiv-f2" =
   in
   (* print_constraint_result ~env exp; *)
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -1895,13 +1870,13 @@ let%expect_test "ambiv-f2" =
                                                     └──Desc: Application
                                                        └──Expression:
                                                           └──Type expr: Arrow
-                                                             └──Type expr: Variable: α442
+                                                             └──Type expr: Constructor: int
                                                              └──Type expr: Arrow
                                                                 └──Type expr: Constructor: int
                                                                 └──Type expr: Constructor: bool
                                                           └──Desc: Primitive: (=)
                                                        └──Expression:
-                                                          └──Type expr: Variable: α442
+                                                          └──Type expr: Constructor: int
                                                           └──Desc: Variable
                                                              └──Variable: y
                                                  └──Expression:
@@ -1947,108 +1922,107 @@ let%expect_test "ambiv-g" =
   in
   (* print_constraint_result ~env exp; *)
   print_infer_result ~env exp;
-  [%expect
-    {|
-      Variables:
-      Expression:
-      └──Expression:
-         └──Type expr: Constructor: unit
-         └──Desc: Let
-            └──Value bindings:
-               └──Value binding:
-                  └──Pattern:
-                     └──Type expr: Arrow
-                        └──Type expr: Constructor: eq
-                           └──Type expr: Variable: α504
-                           └──Type expr: Constructor: int
-                        └──Type expr: Arrow
-                           └──Type expr: Variable: α504
-                           └──Type expr: Variable: α504
-                     └──Desc: Variable: g
-                  └──Abstraction:
-                     └──Variables: α504
-                     └──Expression:
-                        └──Type expr: Arrow
-                           └──Type expr: Constructor: eq
-                              └──Type expr: Variable: α504
-                              └──Type expr: Constructor: int
-                           └──Type expr: Arrow
-                              └──Type expr: Variable: α504
-                              └──Type expr: Variable: α504
-                        └──Desc: Function
-                           └──Pattern:
-                              └──Type expr: Constructor: eq
-                                 └──Type expr: Variable: α504
-                                 └──Type expr: Constructor: int
-                              └──Desc: Variable: x
-                           └──Expression:
-                              └──Type expr: Arrow
-                                 └──Type expr: Variable: α504
-                                 └──Type expr: Variable: α504
-                              └──Desc: Function
-                                 └──Pattern:
-                                    └──Type expr: Variable: α504
-                                    └──Desc: Variable: y
-                                 └──Expression:
-                                    └──Type expr: Variable: α504
-                                    └──Desc: Match
-                                       └──Expression:
-                                          └──Type expr: Constructor: eq
-                                             └──Type expr: Variable: α504
-                                             └──Type expr: Constructor: int
-                                          └──Desc: Variable
-                                             └──Variable: x
-                                       └──Type expr: Constructor: eq
-                                          └──Type expr: Variable: α504
-                                          └──Type expr: Constructor: int
-                                       └──Cases:
-                                          └──Case:
-                                             └──Pattern:
-                                                └──Type expr: Constructor: eq
-                                                   └──Type expr: Variable: α504
-                                                   └──Type expr: Constructor: int
-                                                └──Desc: Construct
-                                                   └──Constructor description:
-                                                      └──Name: Refl
-                                                      └──Constructor type:
-                                                         └──Type expr: Constructor: eq
-                                                            └──Type expr: Variable: α504
-                                                            └──Type expr: Constructor: int
-                                             └──Expression:
-                                                └──Type expr: Variable: α504
-                                                └──Desc: If
-                                                   └──Expression:
-                                                      └──Type expr: Constructor: bool
-                                                      └──Desc: Application
-                                                         └──Expression:
-                                                            └──Type expr: Arrow
-                                                               └──Type expr: Constructor: int
-                                                               └──Type expr: Constructor: bool
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Variable: α504
-                                                                     └──Type expr: Arrow
-                                                                        └──Type expr: Constructor: int
-                                                                        └──Type expr: Constructor: bool
-                                                                  └──Desc: Primitive: (=)
-                                                               └──Expression:
-                                                                  └──Type expr: Variable: α504
-                                                                  └──Desc: Variable
-                                                                     └──Variable: y
-                                                         └──Expression:
-                                                            └──Type expr: Constructor: int
-                                                            └──Desc: Constant: 0
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α504
-                                                      └──Desc: Variable
-                                                         └──Variable: y
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α504
-                                                      └──Desc: Constant: 0
-            └──Expression:
-               └──Type expr: Constructor: unit
-               └──Desc: Constant: () |}]
+  [%expect{|
+    Variables:
+    Expression:
+    └──Expression:
+       └──Type expr: Constructor: unit
+       └──Desc: Let
+          └──Value bindings:
+             └──Value binding:
+                └──Pattern:
+                   └──Type expr: Arrow
+                      └──Type expr: Constructor: eq
+                         └──Type expr: Variable: α511
+                         └──Type expr: Constructor: int
+                      └──Type expr: Arrow
+                         └──Type expr: Variable: α511
+                         └──Type expr: Variable: α511
+                   └──Desc: Variable: g
+                └──Abstraction:
+                   └──Variables: α511
+                   └──Expression:
+                      └──Type expr: Arrow
+                         └──Type expr: Constructor: eq
+                            └──Type expr: Variable: α511
+                            └──Type expr: Constructor: int
+                         └──Type expr: Arrow
+                            └──Type expr: Variable: α511
+                            └──Type expr: Variable: α511
+                      └──Desc: Function
+                         └──Pattern:
+                            └──Type expr: Constructor: eq
+                               └──Type expr: Variable: α511
+                               └──Type expr: Constructor: int
+                            └──Desc: Variable: x
+                         └──Expression:
+                            └──Type expr: Arrow
+                               └──Type expr: Variable: α511
+                               └──Type expr: Variable: α511
+                            └──Desc: Function
+                               └──Pattern:
+                                  └──Type expr: Variable: α511
+                                  └──Desc: Variable: y
+                               └──Expression:
+                                  └──Type expr: Variable: α511
+                                  └──Desc: Match
+                                     └──Expression:
+                                        └──Type expr: Constructor: eq
+                                           └──Type expr: Variable: α511
+                                           └──Type expr: Constructor: int
+                                        └──Desc: Variable
+                                           └──Variable: x
+                                     └──Type expr: Constructor: eq
+                                        └──Type expr: Variable: α511
+                                        └──Type expr: Constructor: int
+                                     └──Cases:
+                                        └──Case:
+                                           └──Pattern:
+                                              └──Type expr: Constructor: eq
+                                                 └──Type expr: Variable: α511
+                                                 └──Type expr: Constructor: int
+                                              └──Desc: Construct
+                                                 └──Constructor description:
+                                                    └──Name: Refl
+                                                    └──Constructor type:
+                                                       └──Type expr: Constructor: eq
+                                                          └──Type expr: Variable: α511
+                                                          └──Type expr: Constructor: int
+                                           └──Expression:
+                                              └──Type expr: Variable: α511
+                                              └──Desc: If
+                                                 └──Expression:
+                                                    └──Type expr: Constructor: bool
+                                                    └──Desc: Application
+                                                       └──Expression:
+                                                          └──Type expr: Arrow
+                                                             └──Type expr: Constructor: int
+                                                             └──Type expr: Constructor: bool
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: int
+                                                                   └──Type expr: Arrow
+                                                                      └──Type expr: Constructor: int
+                                                                      └──Type expr: Constructor: bool
+                                                                └──Desc: Primitive: (=)
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: int
+                                                                └──Desc: Variable
+                                                                   └──Variable: y
+                                                       └──Expression:
+                                                          └──Type expr: Constructor: int
+                                                          └──Desc: Constant: 0
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α511
+                                                    └──Desc: Variable
+                                                       └──Variable: y
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α511
+                                                    └──Desc: Constant: 0
+          └──Expression:
+             └──Type expr: Constructor: unit
+             └──Desc: Constant: () |}]
 
 let%expect_test "ambiv-p" =
   let env = add_eq Env.empty in
@@ -2085,8 +2059,7 @@ let%expect_test "ambiv-p" =
   in
   (* print_constraint_result ~env exp; *)
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -2097,22 +2070,22 @@ let%expect_test "ambiv-p" =
                 └──Pattern:
                    └──Type expr: Arrow
                       └──Type expr: Constructor: eq
-                         └──Type expr: Variable: α517
+                         └──Type expr: Variable: α527
                          └──Type expr: Constructor: int
                       └──Type expr: Constructor: int
                    └──Desc: Variable: f
                 └──Abstraction:
-                   └──Variables: α517
+                   └──Variables: α527
                    └──Expression:
                       └──Type expr: Arrow
                          └──Type expr: Constructor: eq
-                            └──Type expr: Variable: α517
+                            └──Type expr: Variable: α527
                             └──Type expr: Constructor: int
                          └──Type expr: Constructor: int
                       └──Desc: Function
                          └──Pattern:
                             └──Type expr: Constructor: eq
-                               └──Type expr: Variable: α517
+                               └──Type expr: Variable: α527
                                └──Type expr: Constructor: int
                             └──Desc: Variable: x
                          └──Expression:
@@ -2130,25 +2103,25 @@ let%expect_test "ambiv-p" =
                                            └──Desc: Match
                                               └──Expression:
                                                  └──Type expr: Constructor: eq
-                                                    └──Type expr: Variable: α517
+                                                    └──Type expr: Variable: α527
                                                     └──Type expr: Constructor: int
                                                  └──Desc: Variable
                                                     └──Variable: x
                                               └──Type expr: Constructor: eq
-                                                 └──Type expr: Variable: α517
+                                                 └──Type expr: Variable: α527
                                                  └──Type expr: Constructor: int
                                               └──Cases:
                                                  └──Case:
                                                     └──Pattern:
                                                        └──Type expr: Constructor: eq
-                                                          └──Type expr: Variable: α517
+                                                          └──Type expr: Variable: α527
                                                           └──Type expr: Constructor: int
                                                        └──Desc: Construct
                                                           └──Constructor description:
                                                              └──Name: Refl
                                                              └──Constructor type:
                                                                 └──Type expr: Constructor: eq
-                                                                   └──Type expr: Variable: α517
+                                                                   └──Type expr: Variable: α527
                                                                    └──Type expr: Constructor: int
                                                     └──Expression:
                                                        └──Type expr: Constructor: int
@@ -2209,8 +2182,7 @@ let%expect_test "coerce" =
   in
   (* print_constraint_result ~env exp; *)
   print_infer_result ~env exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -2221,72 +2193,72 @@ let%expect_test "coerce" =
                 └──Pattern:
                    └──Type expr: Arrow
                       └──Type expr: Constructor: eq
-                         └──Type expr: Variable: α556
                          └──Type expr: Variable: α565
+                         └──Type expr: Variable: α566
                       └──Type expr: Arrow
                          └──Type expr: Constructor: t
-                            └──Type expr: Variable: α556
-                         └──Type expr: Constructor: t
                             └──Type expr: Variable: α565
+                         └──Type expr: Constructor: t
+                            └──Type expr: Variable: α566
                    └──Desc: Variable: coerce
                 └──Abstraction:
-                   └──Variables: α556,α565
+                   └──Variables: α565,α566
                    └──Expression:
                       └──Type expr: Arrow
                          └──Type expr: Constructor: eq
-                            └──Type expr: Variable: α556
                             └──Type expr: Variable: α565
+                            └──Type expr: Variable: α566
                          └──Type expr: Arrow
                             └──Type expr: Constructor: t
-                               └──Type expr: Variable: α556
-                            └──Type expr: Constructor: t
                                └──Type expr: Variable: α565
+                            └──Type expr: Constructor: t
+                               └──Type expr: Variable: α566
                       └──Desc: Function
                          └──Pattern:
                             └──Type expr: Constructor: eq
-                               └──Type expr: Variable: α556
                                └──Type expr: Variable: α565
+                               └──Type expr: Variable: α566
                             └──Desc: Variable: eq
                          └──Expression:
                             └──Type expr: Arrow
                                └──Type expr: Constructor: t
-                                  └──Type expr: Variable: α556
-                               └──Type expr: Constructor: t
                                   └──Type expr: Variable: α565
+                               └──Type expr: Constructor: t
+                                  └──Type expr: Variable: α566
                             └──Desc: Function
                                └──Pattern:
                                   └──Type expr: Constructor: t
-                                     └──Type expr: Variable: α556
+                                     └──Type expr: Variable: α565
                                   └──Desc: Variable: x
                                └──Expression:
                                   └──Type expr: Constructor: t
-                                     └──Type expr: Variable: α565
+                                     └──Type expr: Variable: α566
                                   └──Desc: Match
                                      └──Expression:
                                         └──Type expr: Constructor: eq
-                                           └──Type expr: Variable: α556
                                            └──Type expr: Variable: α565
+                                           └──Type expr: Variable: α566
                                         └──Desc: Variable
                                            └──Variable: eq
                                      └──Type expr: Constructor: eq
-                                        └──Type expr: Variable: α556
                                         └──Type expr: Variable: α565
+                                        └──Type expr: Variable: α566
                                      └──Cases:
                                         └──Case:
                                            └──Pattern:
                                               └──Type expr: Constructor: eq
-                                                 └──Type expr: Variable: α556
                                                  └──Type expr: Variable: α565
+                                                 └──Type expr: Variable: α566
                                               └──Desc: Construct
                                                  └──Constructor description:
                                                     └──Name: Refl
                                                     └──Constructor type:
                                                        └──Type expr: Constructor: eq
-                                                          └──Type expr: Variable: α556
                                                           └──Type expr: Variable: α565
+                                                          └──Type expr: Variable: α566
                                            └──Expression:
                                               └──Type expr: Constructor: t
-                                                 └──Type expr: Variable: α565
+                                                 └──Type expr: Variable: α566
                                               └──Desc: Variable
                                                  └──Variable: x
           └──Expression:
@@ -2306,8 +2278,7 @@ let%expect_test "solve" =
          ~in_:[ Var a1, Var a2 ] #=> (inst "x" a2))
   in
   print_solve_result cst;
-  [%expect
-    {|
+  [%expect{|
     ((Forall (481 482))
      ((Def_poly ()) ((x 481))
       ((Implication (((Var 481) (Var 482)))) ((Instance x) 482))))
@@ -2344,8 +2315,7 @@ let%expect_test "solve-1" =
                    (a4 =~ a7 &~ [ Var a5, Var a6 ] #=> (return ())))))
   in
   print_solve_result cst;
-  [%expect
-    {|
+  [%expect{|
     ((Forall (483))
      ((Def_poly ((484 ((Constr () int))) (485 ((Constr (483 484) eq)))))
       ((x 485))
@@ -2359,20 +2329,20 @@ let%expect_test "abbrev - morel" =
   let abbrevs =
     let open Types.Algebra.Type_former in
     let abbrev_k =
-      let a = Abbrev_type.(make Var) in
-      let pair = Abbrev_type.(make (Structure (Tuple [ a; a ]))) in
-      Abbrev.(make (Constr ([ a ], "K")) pair)
+      let a = Abbrev_type.make_var () in
+      let pair = Abbrev_type.make_former (Tuple [ a; a ]) in
+      Constr ([ a ], "K"), pair
     in
     let abbrev_f =
-      let a = Abbrev_type.(make Var) in
-      let arr = Abbrev_type.(make (Structure (Arrow (a, a)))) in
-      Abbrev.(make (Constr ([ a ], "F")) arr)
+      let a = Abbrev_type.make_var () in
+      let arr = Abbrev_type.make_former (Arrow (a, a)) in
+      Constr ([ a ], "F"), arr
     in
     let abbrev_g =
-      let a = Abbrev_type.(make Var) in
-      let k = Abbrev_type.(make (Structure (Constr ([ a ], "K")))) in
-      let f = Abbrev_type.(make (Structure (Constr ([ k ], "F")))) in
-      Abbrev.(make (Constr ([ a ], "G")) f)
+      let a = Abbrev_type.(make_var ()) in
+      let k = Abbrev_type.(make_former (Constr ([ a ], "K"))) in
+      let f = Abbrev_type.(make_former (Constr ([ k ], "F"))) in
+      Constr ([ a ], "G"), f
     in
     Abbreviations.empty
     |> Abbreviations.add ~abbrev:abbrev_k
@@ -2398,8 +2368,7 @@ let%expect_test "abbrev - morel" =
               , Pexp_app (Pexp_var "f", Pexp_var "x") ) ) )
   in
   print_infer_result ~abbrevs ~env:Env.empty exp;
-  [%expect
-    {|
+  [%expect{|
     Variables:
     Expression:
     └──Expression:
@@ -2446,8 +2415,11 @@ let%expect_test "abbrev - morel" =
                       └──Type expr: Constructor: int
                    └──Desc: Application
                       └──Expression:
-                         └──Type expr: Constructor: G
-                            └──Type expr: Constructor: int
+                         └──Type expr: Arrow
+                            └──Type expr: Constructor: K
+                               └──Type expr: Constructor: int
+                            └──Type expr: Constructor: K
+                               └──Type expr: Constructor: int
                          └──Desc: Variable
                             └──Variable: f
                       └──Expression:
@@ -2607,12 +2579,12 @@ let%expect_test "term - eval" =
                                             ("Int", Some ([], Ppat_var "x"))
                                       ; pc_rhs = Pexp_var "x"
                                       }
-                                      ; { pc_lhs =
+                                    ; { pc_lhs =
                                           Ppat_construct
                                             ("Bool", Some ([], Ppat_var "x"))
                                       ; pc_rhs = Pexp_var "x"
                                       }
-                                      ; { pc_lhs =
+                                    ; { pc_lhs =
                                           Ppat_construct
                                             ("Succ", Some ([], Ppat_var "t"))
                                       ; pc_rhs =
@@ -2689,479 +2661,478 @@ let%expect_test "term - eval" =
   in
   (* print_constraint_result ~env exp; *)
   print_infer_result ~debug:false ~env exp;
-  [%expect
-    {|
-      Variables:
-      Expression:
-      └──Expression:
-         └──Type expr: Constructor: unit
-         └──Desc: Let
-            └──Value bindings:
-               └──Value binding:
-                  └──Pattern:
-                     └──Type expr: Arrow
-                        └──Type expr: Tuple
-                           └──Type expr: Variable: α627
-                           └──Type expr: Variable: α629
-                        └──Type expr: Variable: α627
-                     └──Desc: Variable: fst
-                  └──Abstraction:
-                     └──Variables: α627,α629
-                     └──Expression:
-                        └──Type expr: Arrow
-                           └──Type expr: Tuple
-                              └──Type expr: Variable: α627
-                              └──Type expr: Variable: α629
-                           └──Type expr: Variable: α627
-                        └──Desc: Function
-                           └──Pattern:
-                              └──Type expr: Tuple
-                                 └──Type expr: Variable: α627
-                                 └──Type expr: Variable: α629
-                              └──Desc: Tuple
-                                 └──Pattern:
-                                    └──Type expr: Variable: α627
-                                    └──Desc: Variable: x
-                                 └──Pattern:
-                                    └──Type expr: Variable: α629
-                                    └──Desc: Any
-                           └──Expression:
-                              └──Type expr: Variable: α627
-                              └──Desc: Variable
-                                 └──Variable: x
-            └──Expression:
-               └──Type expr: Constructor: unit
-               └──Desc: Let
-                  └──Value bindings:
-                     └──Value binding:
-                        └──Pattern:
-                           └──Type expr: Arrow
-                              └──Type expr: Tuple
-                                 └──Type expr: Variable: α637
-                                 └──Type expr: Variable: α634
-                              └──Type expr: Variable: α634
-                           └──Desc: Variable: snd
-                        └──Abstraction:
-                           └──Variables: α634,α637
-                           └──Expression:
-                              └──Type expr: Arrow
-                                 └──Type expr: Tuple
-                                    └──Type expr: Variable: α637
-                                    └──Type expr: Variable: α634
-                                 └──Type expr: Variable: α634
-                              └──Desc: Function
-                                 └──Pattern:
-                                    └──Type expr: Tuple
-                                       └──Type expr: Variable: α637
-                                       └──Type expr: Variable: α634
-                                    └──Desc: Tuple
-                                       └──Pattern:
-                                          └──Type expr: Variable: α637
-                                          └──Desc: Any
-                                       └──Pattern:
-                                          └──Type expr: Variable: α634
-                                          └──Desc: Variable: x
-                                 └──Expression:
-                                    └──Type expr: Variable: α634
-                                    └──Desc: Variable
-                                       └──Variable: x
-                  └──Expression:
-                     └──Type expr: Constructor: unit
-                     └──Desc: Let rec
-                        └──Value bindings:
-                           └──Value binding:
-                              └──Variable: eval
-                              └──Abstraction:
-                                 └──Variables: α639
-                                 └──Expression:
-                                    └──Type expr: Arrow
-                                       └──Type expr: Constructor: term
-                                          └──Type expr: Variable: α728
-                                       └──Type expr: Variable: α728
-                                    └──Desc: Function
-                                       └──Pattern:
-                                          └──Type expr: Constructor: term
-                                             └──Type expr: Variable: α728
-                                          └──Desc: Variable: t
-                                       └──Expression:
-                                          └──Type expr: Variable: α728
-                                          └──Desc: Match
-                                             └──Expression:
-                                                └──Type expr: Constructor: term
-                                                   └──Type expr: Variable: α728
-                                                └──Desc: Variable
-                                                   └──Variable: t
-                                             └──Type expr: Constructor: term
-                                                └──Type expr: Variable: α728
-                                             └──Cases:
-                                                └──Case:
-                                                   └──Pattern:
-                                                      └──Type expr: Constructor: term
-                                                         └──Type expr: Variable: α728
-                                                      └──Desc: Construct
-                                                         └──Constructor description:
-                                                            └──Name: Int
-                                                            └──Constructor argument type:
-                                                               └──Type expr: Constructor: int
-                                                            └──Constructor type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                         └──Pattern:
-                                                            └──Type expr: Constructor: int
-                                                            └──Desc: Variable: x
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α728
-                                                      └──Desc: Variable
-                                                         └──Variable: x
-                                                └──Case:
-                                                   └──Pattern:
-                                                      └──Type expr: Constructor: term
-                                                         └──Type expr: Variable: α728
-                                                      └──Desc: Construct
-                                                         └──Constructor description:
-                                                            └──Name: Bool
-                                                            └──Constructor argument type:
-                                                               └──Type expr: Constructor: bool
-                                                            └──Constructor type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                         └──Pattern:
-                                                            └──Type expr: Constructor: bool
-                                                            └──Desc: Variable: x
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α728
-                                                      └──Desc: Variable
-                                                         └──Variable: x
-                                                └──Case:
-                                                   └──Pattern:
-                                                      └──Type expr: Constructor: term
-                                                         └──Type expr: Variable: α728
-                                                      └──Desc: Construct
-                                                         └──Constructor description:
-                                                            └──Name: Succ
-                                                            └──Constructor argument type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Constructor: int
-                                                            └──Constructor type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                         └──Pattern:
-                                                            └──Type expr: Constructor: term
-                                                               └──Type expr: Constructor: int
-                                                            └──Desc: Variable: t
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α728
-                                                      └──Desc: Application
-                                                         └──Expression:
-                                                            └──Type expr: Arrow
-                                                               └──Type expr: Constructor: int
-                                                               └──Type expr: Variable: α728
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Constructor: int
-                                                                     └──Type expr: Arrow
-                                                                        └──Type expr: Constructor: int
-                                                                        └──Type expr: Variable: α728
-                                                                  └──Desc: Primitive: (+)
-                                                               └──Expression:
-                                                                  └──Type expr: Constructor: int
-                                                                  └──Desc: Application
-                                                                     └──Expression:
-                                                                        └──Type expr: Arrow
-                                                                           └──Type expr: Constructor: term
-                                                                              └──Type expr: Constructor: int
-                                                                           └──Type expr: Constructor: int
-                                                                        └──Desc: Variable
-                                                                           └──Variable: eval
-                                                                           └──Type expr: Constructor: int
-                                                                     └──Expression:
-                                                                        └──Type expr: Constructor: term
-                                                                           └──Type expr: Constructor: int
-                                                                        └──Desc: Variable
-                                                                           └──Variable: t
-                                                         └──Expression:
-                                                            └──Type expr: Constructor: int
-                                                            └──Desc: Constant: 1
-                                                └──Case:
-                                                   └──Pattern:
-                                                      └──Type expr: Constructor: term
-                                                         └──Type expr: Variable: α728
-                                                      └──Desc: Construct
-                                                         └──Constructor description:
-                                                            └──Name: If
-                                                            └──Constructor argument type:
-                                                               └──Type expr: Tuple
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Constructor: bool
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α728
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α728
-                                                            └──Constructor type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                         └──Pattern:
-                                                            └──Type expr: Tuple
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Constructor: bool
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                            └──Desc: Tuple
-                                                               └──Pattern:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Constructor: bool
-                                                                  └──Desc: Variable: t1
-                                                               └──Pattern:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α728
-                                                                  └──Desc: Variable: t2
-                                                               └──Pattern:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α728
-                                                                  └──Desc: Variable: t3
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α728
-                                                      └──Desc: If
-                                                         └──Expression:
-                                                            └──Type expr: Constructor: bool
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Constructor: term
-                                                                        └──Type expr: Constructor: bool
-                                                                     └──Type expr: Constructor: bool
-                                                                  └──Desc: Variable
-                                                                     └──Variable: eval
-                                                                     └──Type expr: Constructor: bool
-                                                               └──Expression:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Constructor: bool
-                                                                  └──Desc: Variable
-                                                                     └──Variable: t1
-                                                         └──Expression:
-                                                            └──Type expr: Variable: α728
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Constructor: term
-                                                                        └──Type expr: Variable: α728
-                                                                     └──Type expr: Variable: α728
-                                                                  └──Desc: Variable
-                                                                     └──Variable: eval
-                                                                     └──Type expr: Variable: α728
-                                                               └──Expression:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α728
-                                                                  └──Desc: Variable
-                                                                     └──Variable: t2
-                                                         └──Expression:
-                                                            └──Type expr: Variable: α728
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Constructor: term
-                                                                        └──Type expr: Variable: α728
-                                                                     └──Type expr: Variable: α728
-                                                                  └──Desc: Variable
-                                                                     └──Variable: eval
-                                                                     └──Type expr: Variable: α728
-                                                               └──Expression:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α728
-                                                                  └──Desc: Variable
-                                                                     └──Variable: t3
-                                                └──Case:
-                                                   └──Pattern:
-                                                      └──Type expr: Constructor: term
-                                                         └──Type expr: Variable: α728
-                                                      └──Desc: Construct
-                                                         └──Constructor description:
-                                                            └──Name: Pair
-                                                            └──Constructor argument type:
-                                                               └──Type expr: Tuple
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α740
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α732
-                                                            └──Constructor type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                         └──Pattern:
-                                                            └──Type expr: Tuple
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α740
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α732
-                                                            └──Desc: Tuple
-                                                               └──Pattern:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α740
-                                                                  └──Desc: Variable: t1
-                                                               └──Pattern:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α732
-                                                                  └──Desc: Variable: t2
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α728
-                                                      └──Desc: Tuple
-                                                         └──Expression:
-                                                            └──Type expr: Variable: α740
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Constructor: term
-                                                                        └──Type expr: Variable: α740
-                                                                     └──Type expr: Variable: α740
-                                                                  └──Desc: Variable
-                                                                     └──Variable: eval
-                                                                     └──Type expr: Variable: α740
-                                                               └──Expression:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α740
-                                                                  └──Desc: Variable
-                                                                     └──Variable: t1
-                                                         └──Expression:
-                                                            └──Type expr: Variable: α732
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Constructor: term
-                                                                        └──Type expr: Variable: α732
-                                                                     └──Type expr: Variable: α732
-                                                                  └──Desc: Variable
-                                                                     └──Variable: eval
-                                                                     └──Type expr: Variable: α732
-                                                               └──Expression:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Variable: α732
-                                                                  └──Desc: Variable
-                                                                     └──Variable: t2
-                                                └──Case:
-                                                   └──Pattern:
-                                                      └──Type expr: Constructor: term
-                                                         └──Type expr: Variable: α728
-                                                      └──Desc: Construct
-                                                         └──Constructor description:
-                                                            └──Name: Fst
-                                                            └──Constructor argument type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Tuple
-                                                                     └──Type expr: Variable: α763
-                                                                     └──Type expr: Variable: α764
-                                                            └──Constructor type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                         └──Pattern:
-                                                            └──Type expr: Constructor: term
-                                                               └──Type expr: Tuple
-                                                                  └──Type expr: Variable: α763
-                                                                  └──Type expr: Variable: α764
-                                                            └──Desc: Variable: t
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α728
-                                                      └──Desc: Application
-                                                         └──Expression:
-                                                            └──Type expr: Arrow
-                                                               └──Type expr: Tuple
-                                                                  └──Type expr: Variable: α728
-                                                                  └──Type expr: Variable: α764
-                                                               └──Type expr: Variable: α728
-                                                            └──Desc: Variable
-                                                               └──Variable: fst
-                                                               └──Type expr: Variable: α764
-                                                               └──Type expr: Variable: α728
-                                                         └──Expression:
-                                                            └──Type expr: Tuple
-                                                               └──Type expr: Variable: α728
-                                                               └──Type expr: Variable: α764
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Constructor: term
-                                                                        └──Type expr: Tuple
-                                                                           └──Type expr: Variable: α728
-                                                                           └──Type expr: Variable: α764
-                                                                     └──Type expr: Tuple
-                                                                        └──Type expr: Variable: α728
-                                                                        └──Type expr: Variable: α764
-                                                                  └──Desc: Variable
-                                                                     └──Variable: eval
-                                                                     └──Type expr: Tuple
-                                                                        └──Type expr: Variable: α728
-                                                                        └──Type expr: Variable: α764
-                                                               └──Expression:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Tuple
-                                                                        └──Type expr: Variable: α728
-                                                                        └──Type expr: Variable: α764
-                                                                  └──Desc: Variable
-                                                                     └──Variable: t
-                                                └──Case:
-                                                   └──Pattern:
-                                                      └──Type expr: Constructor: term
-                                                         └──Type expr: Variable: α728
-                                                      └──Desc: Construct
-                                                         └──Constructor description:
-                                                            └──Name: Snd
-                                                            └──Constructor argument type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Tuple
-                                                                     └──Type expr: Variable: α797
-                                                                     └──Type expr: Variable: α789
-                                                            └──Constructor type:
-                                                               └──Type expr: Constructor: term
-                                                                  └──Type expr: Variable: α728
-                                                         └──Pattern:
-                                                            └──Type expr: Constructor: term
-                                                               └──Type expr: Tuple
-                                                                  └──Type expr: Variable: α797
-                                                                  └──Type expr: Variable: α789
-                                                            └──Desc: Variable: t
-                                                   └──Expression:
-                                                      └──Type expr: Variable: α728
-                                                      └──Desc: Application
-                                                         └──Expression:
-                                                            └──Type expr: Arrow
-                                                               └──Type expr: Tuple
-                                                                  └──Type expr: Variable: α797
-                                                                  └──Type expr: Variable: α728
-                                                               └──Type expr: Variable: α728
-                                                            └──Desc: Variable
-                                                               └──Variable: snd
-                                                               └──Type expr: Variable: α728
-                                                               └──Type expr: Variable: α797
-                                                         └──Expression:
-                                                            └──Type expr: Tuple
-                                                               └──Type expr: Variable: α797
-                                                               └──Type expr: Variable: α728
-                                                            └──Desc: Application
-                                                               └──Expression:
-                                                                  └──Type expr: Arrow
-                                                                     └──Type expr: Constructor: term
-                                                                        └──Type expr: Tuple
-                                                                           └──Type expr: Variable: α797
-                                                                           └──Type expr: Variable: α728
-                                                                     └──Type expr: Tuple
-                                                                        └──Type expr: Variable: α797
-                                                                        └──Type expr: Variable: α728
-                                                                  └──Desc: Variable
-                                                                     └──Variable: eval
-                                                                     └──Type expr: Tuple
-                                                                        └──Type expr: Variable: α797
-                                                                        └──Type expr: Variable: α728
-                                                               └──Expression:
-                                                                  └──Type expr: Constructor: term
-                                                                     └──Type expr: Tuple
-                                                                        └──Type expr: Variable: α797
-                                                                        └──Type expr: Variable: α728
-                                                                  └──Desc: Variable
-                                                                     └──Variable: t
-                        └──Expression:
-                           └──Type expr: Constructor: unit
-                           └──Desc: Constant: () |}]
+  [%expect{|
+    Variables:
+    Expression:
+    └──Expression:
+       └──Type expr: Constructor: unit
+       └──Desc: Let
+          └──Value bindings:
+             └──Value binding:
+                └──Pattern:
+                   └──Type expr: Arrow
+                      └──Type expr: Tuple
+                         └──Type expr: Variable: α637
+                         └──Type expr: Variable: α639
+                      └──Type expr: Variable: α637
+                   └──Desc: Variable: fst
+                └──Abstraction:
+                   └──Variables: α639,α637
+                   └──Expression:
+                      └──Type expr: Arrow
+                         └──Type expr: Tuple
+                            └──Type expr: Variable: α637
+                            └──Type expr: Variable: α639
+                         └──Type expr: Variable: α637
+                      └──Desc: Function
+                         └──Pattern:
+                            └──Type expr: Tuple
+                               └──Type expr: Variable: α637
+                               └──Type expr: Variable: α639
+                            └──Desc: Tuple
+                               └──Pattern:
+                                  └──Type expr: Variable: α637
+                                  └──Desc: Variable: x
+                               └──Pattern:
+                                  └──Type expr: Variable: α639
+                                  └──Desc: Any
+                         └──Expression:
+                            └──Type expr: Variable: α637
+                            └──Desc: Variable
+                               └──Variable: x
+          └──Expression:
+             └──Type expr: Constructor: unit
+             └──Desc: Let
+                └──Value bindings:
+                   └──Value binding:
+                      └──Pattern:
+                         └──Type expr: Arrow
+                            └──Type expr: Tuple
+                               └──Type expr: Variable: α647
+                               └──Type expr: Variable: α644
+                            └──Type expr: Variable: α644
+                         └──Desc: Variable: snd
+                      └──Abstraction:
+                         └──Variables: α647,α644
+                         └──Expression:
+                            └──Type expr: Arrow
+                               └──Type expr: Tuple
+                                  └──Type expr: Variable: α647
+                                  └──Type expr: Variable: α644
+                               └──Type expr: Variable: α644
+                            └──Desc: Function
+                               └──Pattern:
+                                  └──Type expr: Tuple
+                                     └──Type expr: Variable: α647
+                                     └──Type expr: Variable: α644
+                                  └──Desc: Tuple
+                                     └──Pattern:
+                                        └──Type expr: Variable: α647
+                                        └──Desc: Any
+                                     └──Pattern:
+                                        └──Type expr: Variable: α644
+                                        └──Desc: Variable: x
+                               └──Expression:
+                                  └──Type expr: Variable: α644
+                                  └──Desc: Variable
+                                     └──Variable: x
+                └──Expression:
+                   └──Type expr: Constructor: unit
+                   └──Desc: Let rec
+                      └──Value bindings:
+                         └──Value binding:
+                            └──Variable: eval
+                            └──Abstraction:
+                               └──Variables: α651
+                               └──Expression:
+                                  └──Type expr: Arrow
+                                     └──Type expr: Constructor: term
+                                        └──Type expr: Variable: α738
+                                     └──Type expr: Variable: α15
+                                  └──Desc: Function
+                                     └──Pattern:
+                                        └──Type expr: Constructor: term
+                                           └──Type expr: Variable: α738
+                                        └──Desc: Variable: t
+                                     └──Expression:
+                                        └──Type expr: Variable: α15
+                                        └──Desc: Match
+                                           └──Expression:
+                                              └──Type expr: Constructor: term
+                                                 └──Type expr: Variable: α738
+                                              └──Desc: Variable
+                                                 └──Variable: t
+                                           └──Type expr: Constructor: term
+                                              └──Type expr: Variable: α738
+                                           └──Cases:
+                                              └──Case:
+                                                 └──Pattern:
+                                                    └──Type expr: Constructor: term
+                                                       └──Type expr: Variable: α738
+                                                    └──Desc: Construct
+                                                       └──Constructor description:
+                                                          └──Name: Int
+                                                          └──Constructor argument type:
+                                                             └──Type expr: Constructor: int
+                                                          └──Constructor type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                       └──Pattern:
+                                                          └──Type expr: Constructor: int
+                                                          └──Desc: Variable: x
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α15
+                                                    └──Desc: Variable
+                                                       └──Variable: x
+                                              └──Case:
+                                                 └──Pattern:
+                                                    └──Type expr: Constructor: term
+                                                       └──Type expr: Variable: α738
+                                                    └──Desc: Construct
+                                                       └──Constructor description:
+                                                          └──Name: Bool
+                                                          └──Constructor argument type:
+                                                             └──Type expr: Constructor: bool
+                                                          └──Constructor type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                       └──Pattern:
+                                                          └──Type expr: Constructor: bool
+                                                          └──Desc: Variable: x
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α15
+                                                    └──Desc: Variable
+                                                       └──Variable: x
+                                              └──Case:
+                                                 └──Pattern:
+                                                    └──Type expr: Constructor: term
+                                                       └──Type expr: Variable: α738
+                                                    └──Desc: Construct
+                                                       └──Constructor description:
+                                                          └──Name: Succ
+                                                          └──Constructor argument type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Constructor: int
+                                                          └──Constructor type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                       └──Pattern:
+                                                          └──Type expr: Constructor: term
+                                                             └──Type expr: Constructor: int
+                                                          └──Desc: Variable: t
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α15
+                                                    └──Desc: Application
+                                                       └──Expression:
+                                                          └──Type expr: Arrow
+                                                             └──Type expr: Constructor: int
+                                                             └──Type expr: Constructor: int
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: int
+                                                                   └──Type expr: Arrow
+                                                                      └──Type expr: Constructor: int
+                                                                      └──Type expr: Constructor: int
+                                                                └──Desc: Primitive: (+)
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: int
+                                                                └──Desc: Application
+                                                                   └──Expression:
+                                                                      └──Type expr: Arrow
+                                                                         └──Type expr: Constructor: term
+                                                                            └──Type expr: Constructor: int
+                                                                         └──Type expr: Constructor: int
+                                                                      └──Desc: Variable
+                                                                         └──Variable: eval
+                                                                         └──Type expr: Constructor: int
+                                                                   └──Expression:
+                                                                      └──Type expr: Constructor: term
+                                                                         └──Type expr: Constructor: int
+                                                                      └──Desc: Variable
+                                                                         └──Variable: t
+                                                       └──Expression:
+                                                          └──Type expr: Constructor: int
+                                                          └──Desc: Constant: 1
+                                              └──Case:
+                                                 └──Pattern:
+                                                    └──Type expr: Constructor: term
+                                                       └──Type expr: Variable: α738
+                                                    └──Desc: Construct
+                                                       └──Constructor description:
+                                                          └──Name: If
+                                                          └──Constructor argument type:
+                                                             └──Type expr: Tuple
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Constructor: bool
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α738
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α738
+                                                          └──Constructor type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                       └──Pattern:
+                                                          └──Type expr: Tuple
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Constructor: bool
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                          └──Desc: Tuple
+                                                             └──Pattern:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Constructor: bool
+                                                                └──Desc: Variable: t1
+                                                             └──Pattern:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α738
+                                                                └──Desc: Variable: t2
+                                                             └──Pattern:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α738
+                                                                └──Desc: Variable: t3
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α15
+                                                    └──Desc: If
+                                                       └──Expression:
+                                                          └──Type expr: Constructor: bool
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: term
+                                                                      └──Type expr: Constructor: bool
+                                                                   └──Type expr: Constructor: bool
+                                                                └──Desc: Variable
+                                                                   └──Variable: eval
+                                                                   └──Type expr: Constructor: bool
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Constructor: bool
+                                                                └──Desc: Variable
+                                                                   └──Variable: t1
+                                                       └──Expression:
+                                                          └──Type expr: Variable: α738
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: term
+                                                                      └──Type expr: Variable: α738
+                                                                   └──Type expr: Variable: α738
+                                                                └──Desc: Variable
+                                                                   └──Variable: eval
+                                                                   └──Type expr: Variable: α738
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α738
+                                                                └──Desc: Variable
+                                                                   └──Variable: t2
+                                                       └──Expression:
+                                                          └──Type expr: Variable: α738
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: term
+                                                                      └──Type expr: Variable: α738
+                                                                   └──Type expr: Variable: α738
+                                                                └──Desc: Variable
+                                                                   └──Variable: eval
+                                                                   └──Type expr: Variable: α738
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α738
+                                                                └──Desc: Variable
+                                                                   └──Variable: t3
+                                              └──Case:
+                                                 └──Pattern:
+                                                    └──Type expr: Constructor: term
+                                                       └──Type expr: Variable: α738
+                                                    └──Desc: Construct
+                                                       └──Constructor description:
+                                                          └──Name: Pair
+                                                          └──Constructor argument type:
+                                                             └──Type expr: Tuple
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α760
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α761
+                                                          └──Constructor type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                       └──Pattern:
+                                                          └──Type expr: Tuple
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α760
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α761
+                                                          └──Desc: Tuple
+                                                             └──Pattern:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α760
+                                                                └──Desc: Variable: t1
+                                                             └──Pattern:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α761
+                                                                └──Desc: Variable: t2
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α15
+                                                    └──Desc: Tuple
+                                                       └──Expression:
+                                                          └──Type expr: Variable: α16
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: term
+                                                                      └──Type expr: Variable: α16
+                                                                   └──Type expr: Variable: α16
+                                                                └──Desc: Variable
+                                                                   └──Variable: eval
+                                                                   └──Type expr: Variable: α16
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α16
+                                                                └──Desc: Variable
+                                                                   └──Variable: t1
+                                                       └──Expression:
+                                                          └──Type expr: Variable: α17
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: term
+                                                                      └──Type expr: Variable: α17
+                                                                   └──Type expr: Variable: α17
+                                                                └──Desc: Variable
+                                                                   └──Variable: eval
+                                                                   └──Type expr: Variable: α17
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Variable: α17
+                                                                └──Desc: Variable
+                                                                   └──Variable: t2
+                                              └──Case:
+                                                 └──Pattern:
+                                                    └──Type expr: Constructor: term
+                                                       └──Type expr: Variable: α738
+                                                    └──Desc: Construct
+                                                       └──Constructor description:
+                                                          └──Name: Fst
+                                                          └──Constructor argument type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Tuple
+                                                                   └──Type expr: Variable: α788
+                                                                   └──Type expr: Variable: α791
+                                                          └──Constructor type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                       └──Pattern:
+                                                          └──Type expr: Constructor: term
+                                                             └──Type expr: Tuple
+                                                                └──Type expr: Variable: α788
+                                                                └──Type expr: Variable: α791
+                                                          └──Desc: Variable: t
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α15
+                                                    └──Desc: Application
+                                                       └──Expression:
+                                                          └──Type expr: Arrow
+                                                             └──Type expr: Tuple
+                                                                └──Type expr: Variable: α788
+                                                                └──Type expr: Variable: α791
+                                                             └──Type expr: Variable: α788
+                                                          └──Desc: Variable
+                                                             └──Variable: fst
+                                                             └──Type expr: Variable: α791
+                                                             └──Type expr: Variable: α788
+                                                       └──Expression:
+                                                          └──Type expr: Tuple
+                                                             └──Type expr: Variable: α788
+                                                             └──Type expr: Variable: α791
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: term
+                                                                      └──Type expr: Tuple
+                                                                         └──Type expr: Variable: α788
+                                                                         └──Type expr: Variable: α791
+                                                                   └──Type expr: Tuple
+                                                                      └──Type expr: Variable: α788
+                                                                      └──Type expr: Variable: α791
+                                                                └──Desc: Variable
+                                                                   └──Variable: eval
+                                                                   └──Type expr: Tuple
+                                                                      └──Type expr: Variable: α788
+                                                                      └──Type expr: Variable: α791
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Tuple
+                                                                      └──Type expr: Variable: α788
+                                                                      └──Type expr: Variable: α791
+                                                                └──Desc: Variable
+                                                                   └──Variable: t
+                                              └──Case:
+                                                 └──Pattern:
+                                                    └──Type expr: Constructor: term
+                                                       └──Type expr: Variable: α738
+                                                    └──Desc: Construct
+                                                       └──Constructor description:
+                                                          └──Name: Snd
+                                                          └──Constructor argument type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Tuple
+                                                                   └──Type expr: Variable: α808
+                                                                   └──Type expr: Variable: α809
+                                                          └──Constructor type:
+                                                             └──Type expr: Constructor: term
+                                                                └──Type expr: Variable: α738
+                                                       └──Pattern:
+                                                          └──Type expr: Constructor: term
+                                                             └──Type expr: Tuple
+                                                                └──Type expr: Variable: α808
+                                                                └──Type expr: Variable: α809
+                                                          └──Desc: Variable: t
+                                                 └──Expression:
+                                                    └──Type expr: Variable: α15
+                                                    └──Desc: Application
+                                                       └──Expression:
+                                                          └──Type expr: Arrow
+                                                             └──Type expr: Tuple
+                                                                └──Type expr: Variable: α808
+                                                                └──Type expr: Variable: α21
+                                                             └──Type expr: Variable: α809
+                                                          └──Desc: Variable
+                                                             └──Variable: snd
+                                                             └──Type expr: Variable: α21
+                                                             └──Type expr: Variable: α808
+                                                       └──Expression:
+                                                          └──Type expr: Tuple
+                                                             └──Type expr: Variable: α808
+                                                             └──Type expr: Variable: α21
+                                                          └──Desc: Application
+                                                             └──Expression:
+                                                                └──Type expr: Arrow
+                                                                   └──Type expr: Constructor: term
+                                                                      └──Type expr: Tuple
+                                                                         └──Type expr: Variable: α808
+                                                                         └──Type expr: Variable: α21
+                                                                   └──Type expr: Tuple
+                                                                      └──Type expr: Variable: α808
+                                                                      └──Type expr: Variable: α21
+                                                                └──Desc: Variable
+                                                                   └──Variable: eval
+                                                                   └──Type expr: Tuple
+                                                                      └──Type expr: Variable: α808
+                                                                      └──Type expr: Variable: α21
+                                                             └──Expression:
+                                                                └──Type expr: Constructor: term
+                                                                   └──Type expr: Tuple
+                                                                      └──Type expr: Variable: α808
+                                                                      └──Type expr: Variable: α21
+                                                                └──Desc: Variable
+                                                                   └──Variable: t
+                      └──Expression:
+                         └──Type expr: Constructor: unit
+                         └──Desc: Constant: () |}]
 (* 
 let%expect_test "solve-1" =
   let open Constraint in


### PR DESCRIPTION
In #15, we added the notion of a `Structure`. This was added for composability reasons + to generalize the unifier (aiding testing, etc). 

However, this hasn't proved as composable as initially hoped. This PR aims at addressing the composability issues (particularly surrounding metadata). 

Solution: We explicitly split a structure into a descriptor `'a desc` (the syntactic definition of the structure) and some metadata
`'a metadata`. A structure is then defined as the pair: `(desc, metadata)`. 

For example: Abbreviations (from Morell) would be split into:
- A productive view for `'a desc`
- The metadata consists of a non-productive view. 