### PR TITLE
CI Setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  build:
+    docker:
+      - image: ocaml/opam2:debian-10-ocaml-4.12 
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - restore_cache:
+          key: cache-{{ checksum "dromedary.opam" }}
+      - run:
+          name: "Install dependencies"
+          command: sudo apt-get install -y m4  && opam install --yes . --deps-only
+      - save_cache:
+          key: cache-{{ checksum "dromedary.opam" }}
+          paths:
+            - ~/.opam
+      - run:
+          name: "Build"
+          command: opam exec -- BISECT_ENABLE=yes dune build
+      - run:
+          name: "Tests"
+          command: opam exec -- dune runtest
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  build-workflow:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           key: cache-{{ checksum "dromedary.opam" }}
       - run:
           name: "Install dependencies"
-          command: sudo apt-get install -y m4  && opam install --yes . --deps-only
+          command: sudo apt-get install -y m4 && opam update && opam upgrade && opam install --yes . --deps-only
       - save_cache:
           key: cache-{{ checksum "dromedary.opam" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum "dromedary.opam" }}
       - run:
+          name: "Opam update"
+          command: opam update
+      - run:
           name: "Install dependencies"
           command: sudo apt-get install -y m4  && opam install --yes . --deps-only
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,16 +7,13 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: ocaml/opam2:debian-10-ocaml-4.12 
+      - image: ocaml/opam:debian-10-ocaml-4.12.0 
     # Add steps to the job
     # See: https://circleci.com/docs/2.0/configuration-reference/#steps
     steps:
       - checkout
       - restore_cache:
           key: cache-{{ checksum "dromedary.opam" }}
-      - run:
-          name: "Opam update"
-          command: opam update
       - run:
           name: "Install dependencies"
           command: sudo apt-get install -y m4  && opam install --yes . --deps-only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum "dromedary.opam" }}
       - run:
-          name: "Update opam, adding pins"
-          command: opam update && opam pin add ppx_deriving_qcheck git+https://github.com/johnyob/qcheck.git
+          name: "Update opam"
+          command: opam update
       - run:
           name: "Install project dependencies"
           command: opam install --yes . --deps-only && make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           key: cache-{{ checksum "dromedary.opam" }}
       - run:
           name: "Update opam, adding pins"
-          command: opam update && opam upgrade && eval $(opam env) && opam pin add ppx_deriving_qcheck git+https://github.com/johnyob/qcheck.git
+          command: opam update && opam pin add ppx_deriving_qcheck git+https://github.com/johnyob/qcheck.git
       - run:
           name: "Install project dependencies"
           command: opam install --yes . --deps-only && make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: ocaml/opam:debian-10-ocaml-4.12.0 
+      - image: ocaml/opam:debian-10-ocaml-4.12
     # Add steps to the job
     # See: https://circleci.com/docs/2.0/configuration-reference/#steps
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,11 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum "dromedary.opam" }}
       - run:
-          name: "Install dependencies"
-          command: sudo apt-get install -y m4 && opam update && opam upgrade && eval $(opam env) && opam install --yes . --deps-only
+          name: "Install system dependencies and update opam w/ pins"
+          command: sudo apt-get install -y m4 && opam update && opam upgrade && eval $(opam env) && opam pin add ppx_deriving_qcheck git+https://github.com/vch9/qcheck.git
+      - run:
+          name: "Instal project dependencies"
+          command: opam install --yes . --deps-only
       - save_cache:
           key: cache-{{ checksum "dromedary.opam" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           key: cache-{{ checksum "dromedary.opam" }}
       - run:
           name: "Update opam, adding pins"
-          command: opam update && opam upgrade && eval $(opam env) && opam pin add ppx_deriving_qcheck git+https://github.com/vch9/qcheck.git
+          command: opam update && opam upgrade && eval $(opam env) && opam pin add ppx_deriving_qcheck git+https://github.com/johnyob/qcheck.git
       - run:
           name: "Install project dependencies"
           command: opam install --yes . --deps-only && make install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           key: cache-{{ checksum "dromedary.opam" }}
       - run:
           name: "Install dependencies"
-          command: sudo apt-get install -y m4 && opam update && opam upgrade && opam install --yes . --deps-only
+          command: sudo apt-get install -y m4 && opam update && opam upgrade && eval $(opam env) && opam install --yes . --deps-only
       - save_cache:
           key: cache-{{ checksum "dromedary.opam" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,21 +15,18 @@ jobs:
       - restore_cache:
           key: cache-{{ checksum "dromedary.opam" }}
       - run:
-          name: "Install system dependencies and update opam w/ pins"
-          command: sudo apt-get install -y m4 && opam update && opam upgrade && eval $(opam env) && opam pin add ppx_deriving_qcheck git+https://github.com/vch9/qcheck.git
+          name: "Update opam, adding pins"
+          command: opam update && opam upgrade && eval $(opam env) && opam pin add ppx_deriving_qcheck git+https://github.com/vch9/qcheck.git
       - run:
-          name: "Instal project dependencies"
-          command: opam install --yes . --deps-only
+          name: "Install project dependencies"
+          command: opam install --yes . --deps-only && make install
       - save_cache:
           key: cache-{{ checksum "dromedary.opam" }}
           paths:
             - ~/.opam
       - run:
-          name: "Build"
-          command: opam exec -- BISECT_ENABLE=yes dune build
-      - run:
-          name: "Tests"
-          command: opam exec -- dune runtest
+          name: "Run tests and coverage"
+          command: opam exec -- make coverage
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ build:
 install:
 	opam update
 	opam install . --deps-only
-	
+	sudo apt-get install -y libgraph-easy-perl
+
 test:
 	dune runtest
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+default:
+	opam update
+	opam install . --deps-only
+	dune build
+
+build:
+	dune build
+
+install:
+	opam update
+	opam install . --deps-only
+	
+test:
+	dune runtest
+
+clean:
+	dune clean
+
+coverage:
+	make clean
+	BISECT_ENABLE=yes dune build
+	dune runtest
+	bisect-ppx-report html
+	bisect-ppx-report summary

--- a/dromedary.opam
+++ b/dromedary.opam
@@ -9,7 +9,6 @@ license: "MIT"
 homepage: "https://github.com/johnyob/dromedary"
 bug-reports: "https://github.com/johnyob/dromedary/issues"
 depends: [
-  "ocaml" {= "4.12.0"}
   "dune" {>= "2.9" & >= "2.9"}
   "base" {= "v0.14.0"}
   "core" {= "v0.14.1"}
@@ -27,6 +26,7 @@ depends: [
   "qcheck" {= "0.17"}
   "alcotest" {= "1.4.0"}
   "qcheck-alcotest" {= "0.17"}
+  "ppx_deriving_qcheck" {= "0.2.0"}
   "menhir" {= "20210419"}
   "menhirLib" {= "20210419"}
   "odoc" {with-doc}

--- a/dromedary.opam
+++ b/dromedary.opam
@@ -26,7 +26,6 @@ depends: [
   "qcheck" {= "0.17"}
   "alcotest" {= "1.4.0"}
   "qcheck-alcotest" {= "0.17"}
-  "ppx_deriving_qcheck" {= "0.2.0"}
   "menhir" {= "20210419"}
   "menhirLib" {= "20210419"}
   "odoc" {with-doc}

--- a/dromedary.opam
+++ b/dromedary.opam
@@ -10,14 +10,14 @@ homepage: "https://github.com/johnyob/dromedary"
 bug-reports: "https://github.com/johnyob/dromedary/issues"
 depends: [
   "dune" {>= "2.9" & >= "2.9"}
-  "base" {= "v0.14.0"}
+  "base" {= "v0.14.1"}
   "core" {= "v0.14.1"}
   "core_bench" {= "v0.14.0"}
   "core_unix" {= "v0.14.0"}
   "ppx_jane" {= "v0.14.0"}
-  "ppx_sexp_conv" {= "v0.14.1"}
+  "ppx_sexp_conv" {= "v0.14.3"}
   "ppx_compare" {= "v0.14.0"}
-  "ppx_deriving" {= "4.5"}
+  "ppx_deriving" {= "5.2.1"}
   "ppx_let" {= "v0.14.0"}
   "vec" {= "0.3.0"}
   "logs" {= "0.7.0"}

--- a/dune-project
+++ b/dune-project
@@ -19,8 +19,6 @@
  (description
   "Dromedary is an experimental subset of OCaml, using constraint-based type inference!")
  (depends
-  (ocaml
-   (= 4.12.0))
   (dune
    (>= 2.9))
   (base

--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
   (dune
    (>= 2.9))
   (base
-   (= v0.14.0))
+   (= v0.14.1))
   (core
    (= v0.14.1))
   (core_bench
@@ -32,11 +32,11 @@
   (ppx_jane
    (= v0.14.0))
   (ppx_sexp_conv
-   (= v0.14.1))
+   (= v0.14.3))
   (ppx_compare
    (= v0.14.0))
   (ppx_deriving
-   (= 4.5))
+   (= 5.2.1))
   (ppx_let
    (= v0.14.0))
   (vec

--- a/dune-project
+++ b/dune-project
@@ -53,8 +53,6 @@
    (= 1.4.0))
   (qcheck-alcotest
    (= 0.17))
-  (ppx_deriving_qcheck
-   (= 0.2.0))
   (menhir
    (= 20210419))
   (menhirLib

--- a/test/constraints/alcotest/dune
+++ b/test/constraints/alcotest/dune
@@ -2,4 +2,4 @@
  (name test_constraints)
  (libraries base constraints alcotest qcheck qcheck-alcotest)
  (preprocess
-  (pps ppx_jane ppx_deriving_qcheck ppx_deriving.eq)))
+  (pps ppx_jane ppx_deriving.eq)))

--- a/test/constraints/expect/test_unifier.ml
+++ b/test/constraints/expect/test_unifier.ml
@@ -64,13 +64,14 @@ let make_rigid_var =
 
 let ( @ ) f ts = Unifier.Type.make (Structure (Constr (ts, f)))
 
-let print_type t =
-  let content = Type.to_dot t in
+let print_type _t =
+  ()
+  (* let content = Type.to_dot t in
   let out = Stdlib.open_out "/tmp/foo" in
   Stdlib.output_string out content;
   Stdlib.flush out;
   assert (
-    Stdlib.Sys.command "graph-easy /tmp/foo --from graphviz --as boxart" = 0)
+    Stdlib.Sys.command "graph-easy /tmp/foo --from graphviz --as boxart" = 0) *)
 
 
 let%expect_test "Test unify : correctness 1" =

--- a/test/constraints/expect/test_unifier.ml
+++ b/test/constraints/expect/test_unifier.ml
@@ -64,14 +64,13 @@ let make_rigid_var =
 
 let ( @ ) f ts = Unifier.Type.make (Structure (Constr (ts, f)))
 
-let print_type _t =
-  ()
-  (* let content = Type.to_dot t in
+let print_type t =
+  let content = Type.to_dot t in
   let out = Stdlib.open_out "/tmp/foo" in
   Stdlib.output_string out content;
   Stdlib.flush out;
   assert (
-    Stdlib.Sys.command "graph-easy /tmp/foo --from graphviz --as boxart" = 0) *)
+    Stdlib.Sys.command "graph-easy /tmp/foo --from graphviz --as boxart" = 0)
 
 
 let%expect_test "Test unify : correctness 1" =


### PR DESCRIPTION
This PR adds CI testing for Dromedary using CircleCI. 

Changes:
- Makefile for various install scripts
- CircleCI config
- Removal of `ppx_deriving_qcheck` -- caused cyclic generators (for some unknown reason). 
