### PR TITLE
Extensible variants

### DIFF
--- a/src/parsing/parser.mly
+++ b/src/parsing/parser.mly
@@ -160,7 +160,7 @@ let exn_decl ~con ~arg =
     }
   in
   let ext_constr =
-    { pext_name = "exn"; pext_params = []; pext_kind = Pext_decl constr_decl }
+    { pext_kind = Pext_decl constr_decl }
   in
   { ptyexn_constructor = ext_constr }
 
@@ -603,6 +603,8 @@ type_decl_kind:
       { Ptype_record label_decls }
   | EQUAL; type_ = core_type
       { Ptype_alias type_ }
+  | EQUAL; DOT; DOT
+      { Ptype_open }
 
 %inline label_declaration:
   | label = IDENT
@@ -645,6 +647,26 @@ constraints:
     ; arg = option(exception_argument)
       { exn_decl ~con:con_id ~arg }
 
+%inline extension_constructor_kind:
+  | constr_decl = constructor_declaration
+      { Pext_decl constr_decl }
+
+%inline extension_constructor:
+  | ext_kind = extension_constructor_kind
+      { { pext_kind = ext_kind } }
+
+%inline type_ext_declaration:
+  | TYPE
+    ; params = type_param_list
+    ; id = IDENT
+    ; OP_PLUS; EQUAL
+    ; ext_constrs = preceded_or_separated_nonempty_list(BAR, extension_constructor)
+      { { ptyext_name = id
+        ; ptyext_params = params
+        ; ptyext_constructors = ext_constrs 
+        } }
+
+
 structure_item:
   | LET
     ; rec_flag = rec_flag
@@ -657,11 +679,14 @@ structure_item:
     ; EQUAL
     ; prim = STRING
       { Pstr_primitive { pval_name = id; pval_type = scheme; pval_prim = prim } }
+  | type_ext = type_ext_declaration 
+      { Pstr_typext type_ext }
   | type_decls = type_declarations
       { Pstr_type type_decls }
   | EXCEPTION
     ; exn_decl = exception_declaration
       { Pstr_exception exn_decl }
+  
 
 %inline terminated_structure_item:
   | str_item = structure_item

--- a/src/parsing/parsetree.mli
+++ b/src/parsing/parsetree.mli
@@ -205,6 +205,7 @@ and type_decl_kind =
   | Ptype_record of label_declaration list
   | Ptype_abstract
   | Ptype_alias of core_type
+  | Ptype_open
 [@@deriving sexp_of]
 
 (** Label declaration: [l : 'b1 .. 'bm. T] *)
@@ -255,13 +256,7 @@ val pp_constructor_declaration : constructor_declaration Pretty_printer.t
 
 
 (** Extension constructor [type ('a1, ... 'an) t += ...] *)
-type extension_constructor = 
-  { pext_name : string
-      (** Extension type name [t]. *)
-  ; pext_params : string list
-      (** Extension type params: [('a1, ..., 'an)]. *)
-  ; pext_kind : extension_constructor_kind 
-  }
+type extension_constructor = { pext_kind : extension_constructor_kind }
 [@@derving sexp_of]
 
 and extension_constructor_kind = 
@@ -281,6 +276,17 @@ type type_exception =
   { ptyexn_constructor : extension_constructor }
 [@@derving sexp_of]
 
+(** Extensions [type t += ..] *)
+type type_extension = 
+  { ptyext_name : string
+    (* Type name [t] *)
+  ; ptyext_params : string list
+    (** Parameters: [('a1, .., 'an) t] *)
+  ; ptyext_constructors : extension_constructor list
+    (** Constructors [ C1 [of t1] | ... | Cn [of tn] ] *)
+  }
+[@@deriving sexp_of]
+
 type structure_item = 
   | Pstr_value of rec_flag * value_binding list
       (** Structure let binding: [let <rec> P1 = E1 and ... and Pn = En] *)
@@ -288,6 +294,8 @@ type structure_item =
       (** External primitive descriptions *)
   | Pstr_type of type_declaration list
       (** Type declarations [type t1 = ... and ... tn = ...] *)
+  | Pstr_typext of type_extension 
+      (** Type extensions [type t += ...] *)
   | Pstr_exception of type_exception
       (** Exception [exception C <of T>] *)
 [@@deriving sexp_of]

--- a/src/typing/env.ml
+++ b/src/typing/env.ml
@@ -78,12 +78,16 @@ let add_type_decl t type_decl =
   | Type_alias alias ->
     let abbrev = convert_alias alias in
     { t with abbrevs = Constraint.Abbreviations.add t.abbrevs ~abbrev }
-  | Type_abstract -> t
+  | Type_abstract | Type_open -> t
 
 
 let add_ext_constr t ext_constr =
   let { text_kind = Text_decl constr_decl; _ } = ext_constr in
   add_constr_decl t constr_decl
+
+
+let add_type_ext t type_ext =
+  List.fold_left type_ext.tyext_constructors ~init:t ~f:add_ext_constr
 
 
 let to_abbrevs t = t.abbrevs

--- a/src/typing/env.mli
+++ b/src/typing/env.mli
@@ -25,6 +25,8 @@ val add_type_decl : t -> type_declaration -> t
 
 val add_ext_constr : t -> extension_constructor -> t
 
+val add_type_ext : t -> type_extension -> t
+
 val to_abbrevs : t -> Abbreviations.t
 
 (** [find_constr t constr] returns the constructor declaration w/ constructor name [constr]. *)

--- a/src/typing/typedtree.ml
+++ b/src/typing/typedtree.ml
@@ -101,11 +101,18 @@ and extension_constructor_kind = Text_decl of constructor_declaration
 and type_exception = { tyexn_constructor : extension_constructor }
 [@@derving sexp_of]
 
+and type_extension =
+  { tyext_name : string
+  ; tyext_constructors : extension_constructor list
+  }
+[@@deriving sexp_of]
+
 and structure_item =
   | Tstr_value of value_binding list
   | Tstr_value_rec of rec_value_binding list
   | Tstr_primitive of value_description
   | Tstr_type of type_declaration list
+  | Tstr_typext of type_extension
   | Tstr_exception of type_exception
 [@@deriving sexp_of]
 
@@ -299,7 +306,9 @@ let pp_scheme_mach ~indent ppf (variables, type_expr) =
     ppf
     "%sVariables: %s@."
     indent
-    (String.concat ~sep:"," (List.map ~f:(fun t -> Type_var.id t |> Int.to_string) variables));
+    (String.concat
+       ~sep:","
+       (List.map ~f:(fun t -> Type_var.id t |> Int.to_string) variables));
   pp_type_expr_mach ~indent ppf type_expr
 
 
@@ -328,7 +337,11 @@ let pp_extension_constructor_mach ~indent ppf ext_constr =
     ppf
     "%sExtension parameters: %s@."
     indent
-    (String.concat ~sep:" " (List.map ~f:(fun t -> Type_var.id t |> Int.to_string) ext_constr.text_params));
+    (String.concat
+       ~sep:" "
+       (List.map
+          ~f:(fun t -> Type_var.id t |> Int.to_string)
+          ext_constr.text_params));
   pp_extension_constructor_kind_mach ~indent ppf ext_constr.text_kind
 
 
@@ -336,6 +349,15 @@ let pp_type_exception_mach ~indent ppf type_exn =
   Format.fprintf ppf "%sType exception:@." indent;
   let indent = indent_space ^ indent in
   pp_extension_constructor_mach ~indent ppf type_exn.tyexn_constructor
+
+
+let pp_type_extension_mach ~indent ppf type_ext =
+  Format.fprintf ppf "%sType extension:@." indent;
+  let indent = indent_space ^ indent in
+  Format.fprintf ppf "%sExtension name: %s@." indent type_ext.tyext_name;
+  List.iter
+    ~f:(pp_extension_constructor_mach ~indent ppf)
+    type_ext.tyext_constructors
 
 
 let pp_structure_item_mach ~indent ppf str_item =
@@ -357,6 +379,9 @@ let pp_structure_item_mach ~indent ppf str_item =
   | Tstr_exception type_exception ->
     print "Exception";
     pp_type_exception_mach ~indent ppf type_exception
+  | Tstr_typext type_ext ->
+    print "Type Extension";
+    pp_type_extension_mach ~indent ppf type_ext
 
 
 let pp_structure_mach ~indent ppf str =
@@ -386,7 +411,6 @@ let pp_case_mach = to_pp_mach ~pp:pp_case_mach ~name:"Case"
 
 (* let pp_structure_item_mach =
   to_pp_mach ~name:"Structure item" ~pp:pp_structure_item_mach *)
-
 
 let pp_structure_mach = to_pp_mach ~name:"Structure" ~pp:pp_structure_mach
 let pp_expression _ppf = assert false

--- a/src/typing/typedtree.mli
+++ b/src/typing/typedtree.mli
@@ -151,6 +151,15 @@ type type_exception =
   { tyexn_constructor : extension_constructor }
 [@@derving sexp_of]
 
+(** Type extension [type t += ...] *)
+type type_extension = 
+  { tyext_name : string
+      (** Extension type name [t]. *)
+  ; tyext_constructors : extension_constructor list 
+      (** Extension constructors *)
+  }
+[@@deriving sexp_of]
+
 type structure_item = 
   | Tstr_value of value_binding list 
     (** Let expressions *)
@@ -160,6 +169,8 @@ type structure_item =
       (** External primitive descriptions *)
   | Tstr_type of type_declaration list
       (** Type declarations [type t1 = ... and ... tn = ...] *)
+  | Tstr_typext of type_extension
+      (** Type extensions [type t += ...] *)
   | Tstr_exception of type_exception
       (** Exception [exception C <of T>] *)
 [@@deriving sexp_of]

--- a/src/typing/types.ml
+++ b/src/typing/types.ml
@@ -114,6 +114,7 @@ and type_decl_kind =
   | Type_variant of constructor_declaration list
   | Type_abstract
   | Type_alias of alias
+  | Type_open
 [@@deriving sexp_of]
 
 and alias =
@@ -403,6 +404,7 @@ let pp_type_decl_kind_mach ~indent ppf type_decl_kind =
   | Type_alias alias ->
     print "Alias";
     pp_alias_mach ~indent ppf alias
+  | Type_open -> print "Open"
 
 
 let pp_type_declaration_mach ~indent ppf type_decl =

--- a/src/typing/types.mli
+++ b/src/typing/types.mli
@@ -104,6 +104,7 @@ and type_decl_kind =
   | Type_variant of constructor_declaration list
   | Type_abstract
   | Type_alias of alias
+  | Type_open
 [@@deriving sexp_of]
 
 and alias =

--- a/test/parsing/good_structure.ml
+++ b/test/parsing/good_structure.ml
@@ -783,8 +783,6 @@ let%expect_test "exceptions - no argument" =
        └──Structure item: Exception
           └──Type exception:
              └──Extension constructor:
-                └──Extension name: exn
-                └──Extension parameters:
                 └──Extension constructor kind: Declaration
                    └──Constructor declaration:
                       └──Constructor name: Not_found
@@ -843,8 +841,6 @@ let%expect_test "exceptions - argument" =
        └──Structure item: Exception
           └──Type exception:
              └──Extension constructor:
-                └──Extension name: exn
-                └──Extension parameters:
                 └──Extension constructor kind: Declaration
                    └──Constructor declaration:
                       └──Constructor name: Lexer_error


### PR DESCRIPTION
This PR aims to implement extensible variants:
```ocaml
(* Open variant *)
type ('a1, ..., 'an) t = ..;;

(* Extensions *)
type ('a1, ..., 'an) t += 
  | C [of 'b1 ... 'bm. t] constraints E 
  | ... 
;;
```